### PR TITLE
feat: analytical sim + max-wave-only redesign (v3.0.0)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,12 +2,14 @@
 
 ## Key Code Sections
 Search by function name - these are the stable anchors.
-- **Game logic**: `parseUpgrades`, `eventTest`, `FullEventSim`, `avgEvent_short`, `GiveApproxWithUpgraded`, `mcGainForUpgrade`, `quickSim`
-- **UI data**: `upgradeNames`, `maxLevels`, `prestigeUnlocked`, `capUpgIdx`, `CAP_OF_CAPS_IDX`
+- **Game logic**: `parseUpgrades`, `eventTest`, `FullEventSim`, `analyticalSim`, `exactHtkMoments`
+- **Gain system**: `computeUpgradeGain`, `computeGainFromLevels`, `computeCapCompoundGain`, `computeCapOfCapsCompoundGain`
+- **UI data**: `upgradeNames`, `maxLevels`, `prestigeUnlocked`, `capUpgIdx`, `CAP_OF_CAPS_IDX`, `upgradeType`
 - **Persistence**: `saveState`/`loadState`/`exportState`/`importState` using localStorage key `shminer_state`
-- **DOM rendering**: `buildUpgradesDOM`/`buildGemsDOM` (build-once) + `refreshUpgradeValues`/`refreshGemValues`/`renderPrestigeMilestone` (update-in-place)
-- **Budget planner**: `budgetPlan`/`renderBudgetResults`/`budgetBuy` - greedy optimizer with hybrid gain (deterministic + MC cache fallback)
+- **DOM rendering**: `buildUpgradesDOM`/`buildGemsDOM` (build-once) + `refreshUpgradeValues`/`refreshGemValues`/`renderPrestigeMilestone`/`renderPrestigeAdvice` (update-in-place)
+- **Budget planner**: `budgetPlan`/`renderBudgetResults`/`budgetBuy` - greedy optimizer with 2-step lookahead
 - **UX**: `toggleHelp`, `openChangelog`/`closeChangelog`, `showOnboard`/`dismissOnboard`, `prestigeReset`
+- **Validation**: `validateAnalyticalSim` (console), `compareBudgetStrategies` (console)
 
 ## Game Mechanics
 - Upgrades are **sequential**: each requires the previous upgrade in the tier to have at least level 1
@@ -25,28 +27,71 @@ Search by function name - these are the stable anchors.
 - Number formatting: variable decimals (>=100: 0dp, >=10: 1dp, <10: 2dp) to match game display
 
 ## Key Variable Names
-- `approxCache`: cached gain values (number) per upgrade key `{ti}_{uj}`, cleared on any state change. Populated by `refreshUpgradeValues`, consumed by both Next Buy and Budget Planner.
+- `approxCache`: cached gain values (number) per upgrade key `{ti}_{uj}`, cleared on any state change. Populated by `refreshUpgradeValues`, consumed by both Next Buy and Budget Planner. Key `'base'` stores the baseline `analyticalSim` result `[wave, sub, time]`.
 - `CAP_OF_CAPS_IDX`: T4[6] index - the upgrade that increases cap upgrade max levels
 - `capUpgIdx`: index of the "+1 Tier X Upgrade Caps" upgrade within each tier
 - `upgradeInstructions[tier][upgrade]`: functions that apply stat modifications, parameter `lv` = level
-- `GAIN_SIM_RUNS`: number of MC runs for `quickSim`/`mcGainForUpgrade` (currently 200)
+- `upgradeType[tier][upgrade]`: pre-computed classification: `'combat'`, `'speed'`, `'resource'`, `'prestige'`, `'mixed'`, `'cap'`
+- `offenseOnly[tier][upgrade]`: pre-computed flag for pure offense upgrades (gain=0 when player already one-shots)
 
-## Gain Calculation (hybrid system)
-The core challenge: `avgEvent_short` (deterministic) gives gain=0 for HP/prestige upgrades when the player already one-shots enemies. Monte Carlo captures these marginal gains via random crits/blocks.
+## Gain Calculation (analytical system)
+The gain system uses `analyticalSim` - a CLT-based (Central Limit Theorem) analytical simulation that computes expected wave, subzone, and time deterministically.
 
-- `GiveApproxWithUpgraded(ti,uj)`: deterministic sim with +1 level. Used for initial gain detection.
-- `mcGainForUpgrade(ti,uj)`: 200 paired MC runs (base vs upgraded). Fallback when deterministic shows 0.
-- `refreshUpgradeValues`: populates `approxCache` with hybrid gains (det first, MC fallback). Source of truth for both Next Buy and Budget Planner.
-- Budget Planner: uses deterministic gain from its mutated `levels` state, falls back to `approxCache` (MC-based) when det=0.
+### analyticalSim
+Computes expected wave by tracking cumulative damage moments (E[S], Var[S]) across subzones. Uses Gaussian survival probability `P(survive) = Phi((HP - cumE) / sqrt(cumVar))` to determine expected wave without randomness. Returns `[expectedWave, sub, time]`.
+
+Key internals:
+- `exactHtkMoments`: exact E[htk] and Var[htk] via binomial player crit distribution (replaces ceil approximation)
+- Enemy crit damage uses `round()` to match Monte Carlo behavior
+- CLT bias: ~1.4 wave underestimation at high-wave states (Gaussian tail for bounded distributions). Cancels in gain deltas.
+
+### Upgrade type classification
+Pre-computed at startup (like `offenseOnly`):
+- `combat`: directly affects wave via analyticalSim (atk, hp, crit, block, enemy stats)
+- `speed`: only affects time (walkSpeed, gameSpeed) - indirect value via time savings
+- `resource`: only affects drop rates (x5money, x2money) - indirect value via extra resources
+- `prestige`: only affects prestigeBonusScale - at P=0, simulated with P=1
+- `mixed`: combat + speed (e.g., T4[3] +atkSpeed +walkSpeed) - atkSpeed held constant for combat gain to avoid overcrediting
+- `cap`: cap upgrades - compound gain from all maxed upgrades that +1 cap unlocks
+
+### 2-pass gain computation
+`refreshUpgradeValues` populates `approxCache` in two passes:
+1. **Pass 1**: combat + prestige (P>0) gains via `analyticalSim` delta
+2. **Pass 2**: speed, resource, mixed, cap, prestige (P=0) gains using `avgCombatGain` from pass 1
+
+### Cap compound gain
+- Regular caps: sum of wave gains from each maxed upgrade unlocked by cap+1
+- Cap of Caps (T4[6]): cascade depth=2 (T4[6]+1 -> cap upgrades -> regular upgrades)
+- Post-increment guard: only counts upgrades whose max actually increased
+
+## Budget Planner
+Greedy optimizer with 2-step lookahead. Each iteration:
+1. Evaluate all affordable/available upgrades via `computeGainFromLevels`
+2. For the first 20 iterations (and when top gains are close): simulate buying each of the top 5 candidates, find best follow-up, compare pair scores
+3. Override greedy if alternative 2-step path is >=5% better
+4. Buy the selected upgrade, deduct cost, repeat (up to 600 iterations)
+
+`computeGainFromLevels` mirrors `computeUpgradeGain` but operates on a local `levels` array instead of global `upgrades`.
+
+## Prestige Advisor
+Uses the official wiki's optimal prestige milestones: P1, P2, P5, P10, P20, P40.
+Compares current wave against the next milestone's wave requirement. After P40, targets wave 250 (last reward).
 
 ## DOM Pattern
 Inputs are built once with stable IDs (`upg-inp-{ti}-{uj}`, `gem-inp-{i}`, `pres-input`). Values update in-place via `refreshUpgradeValues()`. Do not rebuild the upgrade DOM on value changes - it breaks Tab focus.
+
+## Display Simulation
+`FullEventSim(p, e, 1000)` runs 1000 Monte Carlo event simulations for the results panel (worst/avg/best wave, currencies per run, time). This is separate from the gain calculation system.
 
 ## Performance Notes
 - Budget planner caps at 600 iterations to avoid hanging
 - Sim results panel uses CSS opacity transition (`.simulating` class) instead of innerHTML wipe to prevent flicker
 - Hold-to-repeat uses pointer events (touch-compatible): 400ms delay, 80ms interval
-- Cap upgrades skip MC simulation when no upgrade in the tier is at max level
+- `analyticalSim` is ~0.3ms per call (~20x faster than 200 MC paired runs)
+
+## Validation Harnesses (console only)
+- `validateAnalyticalSim(mcRuns)`: compares analyticalSim vs FullEventSim for 7 game states. Pass threshold: <0.5 wave delta.
+- `compareBudgetStrategies(budgets)`: compares greedy vs 2-step lookahead. Reports wave, iterations, overrides, timing.
 
 ## Data Source
 [Official wiki](https://shminer.miraheze.org/wiki/Events), local copy at `events.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v3.0.0
+- Replace Monte Carlo gain calculation with analytical simulation (deterministic, ~20x faster)
+- Remove res/min optimization mode and Cycle Resource button (single "max wave" target)
+- Indirect value formulas for speed, resource, prestige, and mixed upgrades
+- Cap compound gain: cap upgrades show cascading value from unlocked upgrades
+- Budget planner 2-step lookahead for better upgrade sequencing
+- Prestige advisor with optimal milestones from the official wiki
+
 ## Stargazing v1.5.1
 - Add intro text explaining the tool concept (no perks/skills required)
 - Star counts now read "farms X stars" instead of "X stars"

--- a/index.html
+++ b/index.html
@@ -368,6 +368,22 @@ const offenseOnly=upgradeInstructions.map(tier=>tier.map(fn=>{
   if(Object.keys(enemyStatsBase).some(k=>te[k]!==enemyStatsBase[k]))return false;
   return !Object.keys(playerStatsBase).some(k=>!OFFENSE_STATS.has(k)&&tp[k]!==playerStatsBase[k]);
 }));
+// Classify upgrades by stat category for indirect value formulas
+const SPEED_STATS=new Set(['walkSpeed','gameSpeed','atkSpeed']);
+const RESOURCE_STATS=new Set(['x5money','x2money']);
+const upgradeType=upgradeInstructions.map(tier=>tier.map(fn=>{
+  const tp=Object.assign({},playerStatsBase),te=Object.assign({},enemyStatsBase);
+  fn(1,tp,te);
+  const pc=Object.keys(playerStatsBase).filter(k=>tp[k]!==playerStatsBase[k]);
+  const ec=Object.keys(enemyStatsBase).filter(k=>te[k]!==enemyStatsBase[k]);
+  if(!pc.length&&!ec.length)return'cap';
+  if(ec.length>0)return'combat';
+  if(pc.every(k=>SPEED_STATS.has(k)))return'speed';
+  if(pc.every(k=>RESOURCE_STATS.has(k)))return'resource';
+  if(pc.every(k=>k==='prestigeBonusScale'))return'prestige';
+  if(pc.some(k=>k==='atkSpeed'))return'mixed';
+  return'combat';
+}));
 
 // Apply all upgrade levels + prestige + gems to base stats, return computed player & enemy
 function parseUpgrades(upgs,basePlayer,baseEnemy,prestiges,gems){
@@ -535,21 +551,101 @@ function analyticalSim(player,enemy){
   const sub=Math.max(1,Math.min(5,Math.round(frac*5)||1));
   return[expectedWave,sub,time];
 }
-// Compute wave gain for one upgrade (+1 level) using analyticalSim.
-function computeUpgradeGain(ti,uj,p,e,baseWave){
-  if(offenseOnly[ti][uj]&&get_highest_wave_killed_in_x_hits(p,e,1)>Math.floor(baseWave))return 0;
+// Compute wave gain for one upgrade (+1 level). baseR=[wave,sub,time] from analyticalSim.
+// avgGain = mean of positive combat gains (for indirect value formulas; 0 during pass 1).
+function computeUpgradeGain(ti,uj,p,e,baseR,avgGain){
+  const type=upgradeType[ti][uj];
+  if(type==='cap')return 0;
+  if(offenseOnly[ti][uj]&&get_highest_wave_killed_in_x_hits(p,e,1)>Math.floor(baseR[0]))return 0;
+  if(type==='speed'){
+    if(!avgGain)return 0; // pass 1: skip
+    upgrades[ti][uj]=(upgrades[ti][uj]||0)+1;
+    const{p:pu,e:eu}=parseUpgrades(upgrades,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
+    upgrades[ti][uj]--;
+    const tPct=Math.max(0,(baseR[2]-analyticalSim(pu,eu)[2])/baseR[2]);
+    return tPct*avgGain;
+  }
+  if(type==='resource'){
+    if(!avgGain)return 0;
+    const bm=(1+(p.x2money||0))*(1+4*((p.x5money||0)/100));
+    upgrades[ti][uj]=(upgrades[ti][uj]||0)+1;
+    const{p:pu}=parseUpgrades(upgrades,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
+    upgrades[ti][uj]--;
+    const um=(1+(pu.x2money||0))*(1+4*((pu.x5money||0)/100));
+    return((um-bm)/bm)*avgGain;
+  }
+  if(type==='prestige'&&prestigeCount===0){
+    const{p:bp1,e:be1}=parseUpgrades(upgrades,playerStatsBase,enemyStatsBase,1,gemUp);
+    const w0=analyticalSim(bp1,be1)[0];
+    upgrades[ti][uj]=(upgrades[ti][uj]||0)+1;
+    const{p:up1,e:ue1}=parseUpgrades(upgrades,playerStatsBase,enemyStatsBase,1,gemUp);
+    upgrades[ti][uj]--;
+    return analyticalSim(up1,ue1)[0]-w0;
+  }
+  if(type==='mixed'){
+    upgrades[ti][uj]=(upgrades[ti][uj]||0)+1;
+    const{p:pu,e:eu}=parseUpgrades(upgrades,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
+    upgrades[ti][uj]--;
+    // Combat gain with base atkSpeed (avoids overcrediting atkSpeed combat effect)
+    const savedSpd=pu.atkSpeed;
+    pu.atkSpeed=p.atkSpeed;
+    const cGain=analyticalSim(pu,eu)[0]-baseR[0];
+    // Speed gain from atkSpeed component
+    pu.atkSpeed=savedSpd;
+    const tPct=avgGain?Math.max(0,(baseR[2]-analyticalSim(pu,eu)[2])/baseR[2]):0;
+    return cGain+tPct*avgGain;
+  }
+  // Default: combat via analyticalSim
   upgrades[ti][uj]=(upgrades[ti][uj]||0)+1;
   const{p:pu,e:eu}=parseUpgrades(upgrades,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
   upgrades[ti][uj]--;
-  return analyticalSim(pu,eu)[0]-baseWave;
+  return analyticalSim(pu,eu)[0]-baseR[0];
 }
 // Budget planner variant: uses local levels array instead of global upgrades.
-function computeGainFromLevels(ti,uj,levels,bp,be,baseWave){
-  if(offenseOnly[ti][uj]&&get_highest_wave_killed_in_x_hits(bp,be,1)>Math.floor(baseWave))return 0;
+function computeGainFromLevels(ti,uj,levels,bp,be,baseR,avgGain){
+  const type=upgradeType[ti][uj];
+  if(type==='cap')return 0;
+  if(offenseOnly[ti][uj]&&get_highest_wave_killed_in_x_hits(bp,be,1)>Math.floor(baseR[0]))return 0;
+  if(type==='speed'){
+    if(!avgGain)return 0;
+    levels[ti][uj]++;
+    const{p,e}=parseUpgrades(levels,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
+    levels[ti][uj]--;
+    const tPct=Math.max(0,(baseR[2]-analyticalSim(p,e)[2])/baseR[2]);
+    return tPct*avgGain;
+  }
+  if(type==='resource'){
+    if(!avgGain)return 0;
+    const bm=(1+(bp.x2money||0))*(1+4*((bp.x5money||0)/100));
+    levels[ti][uj]++;
+    const{p}=parseUpgrades(levels,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
+    levels[ti][uj]--;
+    const um=(1+(p.x2money||0))*(1+4*((p.x5money||0)/100));
+    return((um-bm)/bm)*avgGain;
+  }
+  if(type==='prestige'&&prestigeCount===0){
+    const{p:bp1,e:be1}=parseUpgrades(levels,playerStatsBase,enemyStatsBase,1,gemUp);
+    const w0=analyticalSim(bp1,be1)[0];
+    levels[ti][uj]++;
+    const{p:up1,e:ue1}=parseUpgrades(levels,playerStatsBase,enemyStatsBase,1,gemUp);
+    levels[ti][uj]--;
+    return analyticalSim(up1,ue1)[0]-w0;
+  }
+  if(type==='mixed'){
+    levels[ti][uj]++;
+    const{p,e}=parseUpgrades(levels,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
+    levels[ti][uj]--;
+    const savedSpd=p.atkSpeed;
+    p.atkSpeed=bp.atkSpeed;
+    const cGain=analyticalSim(p,e)[0]-baseR[0];
+    p.atkSpeed=savedSpd;
+    const tPct=avgGain?Math.max(0,(baseR[2]-analyticalSim(p,e)[2])/baseR[2]):0;
+    return cGain+tPct*avgGain;
+  }
   levels[ti][uj]++;
   const{p,e}=parseUpgrades(levels,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
   levels[ti][uj]--;
-  return analyticalSim(p,e)[0]-baseWave;
+  return analyticalSim(p,e)[0]-baseR[0];
 }
 
 // ── UI DATA ──────────────────────────────────────────────────
@@ -766,10 +862,10 @@ function buildUpgradesDOM(){
 
 function refreshUpgradeValues(){
   if(!approxCache['base'])
-    approxCache['base']=analyticalSim(cachedP||playerStatsBase,cachedE||enemyStatsBase)[0];
-  const base=approxCache['base'];
+    approxCache['base']=analyticalSim(cachedP||playerStatsBase,cachedE||enemyStatsBase);
+  const baseR=approxCache['base'];
 
-  // First pass: collect all gains
+  // Collect upgrade metadata
   const allGains=[];
   for(let ti=0;ti<4;ti++){
     for(let uj=0;uj<upgradeNames[ti].length;uj++){
@@ -777,21 +873,38 @@ function refreshUpgradeValues(){
       const needsPrev=uj>0&&(upgrades[ti][uj-1]||0)<1;
       const locked=presReq>prestigeCount||needsPrev;
       const maxL=currentMaxLvl(ti,uj),lvl=upgrades[ti][uj]||0;
-      let gain=0;
       const isCap=capUpgIdx[ti]===uj||(ti===3&&uj===CAP_OF_CAPS_IDX);
-      // Cap upgrades only matter if some upgrade in the tier is at its max level
       let capUseful=false;
       if(isCap){for(let u=0;u<upgradeNames[ti].length;u++){if(u!==uj&&(upgrades[ti][u]||0)>=currentMaxLvl(ti,u)){capUseful=true;break}}}
-      if(!locked&&cachedP&&lvl<maxL&&(!isCap||capUseful)){
-        const key=`${ti}_${uj}`;
-        if(!approxCache[key])approxCache[key]=computeUpgradeGain(ti,uj,cachedP,cachedE,base);
-        gain=approxCache[key];
-      }
-      const upgCost=locked||lvl>=maxL?0:costs[ti][uj]*Math.pow(1.25,lvl);
-      const efficiency=upgCost>0&&gain>0?gain/upgCost:0;
-      allGains.push({ti,uj,gain,efficiency,upgCost,locked,needsPrev,lvl,maxL,presReq});
+      const canEval=!locked&&cachedP&&lvl<maxL&&(!isCap||capUseful);
+      allGains.push({ti,uj,gain:0,efficiency:0,upgCost:locked||lvl>=maxL?0:costs[ti][uj]*Math.pow(1.25,lvl),locked,needsPrev,lvl,maxL,presReq,canEval});
     }
   }
+  // Pass 1: combat + prestige (P>0) gains
+  for(const g of allGains){
+    if(!g.canEval)continue;
+    const type=upgradeType[g.ti][g.uj];
+    if(type==='combat'||(type==='prestige'&&prestigeCount>0)){
+      const key=`${g.ti}_${g.uj}`;
+      if(!approxCache[key])approxCache[key]=computeUpgradeGain(g.ti,g.uj,cachedP,cachedE,baseR,0);
+      g.gain=approxCache[key];
+    }
+  }
+  // Compute avgCombatGain for indirect formulas
+  const cGains=allGains.filter(g=>g.gain>0);
+  const avgGain=cGains.length?cGains.reduce((s,g)=>s+g.gain,0)/cGains.length:0;
+  // Pass 2: speed, resource, mixed, prestige at P=0
+  for(const g of allGains){
+    if(!g.canEval||g.gain>0)continue;
+    const type=upgradeType[g.ti][g.uj];
+    if(type==='speed'||type==='resource'||type==='mixed'||(type==='prestige'&&prestigeCount===0)){
+      const key=`${g.ti}_${g.uj}`;
+      if(!approxCache[key])approxCache[key]=computeUpgradeGain(g.ti,g.uj,cachedP,cachedE,baseR,avgGain);
+      g.gain=approxCache[key];
+    }
+  }
+  // Finalize efficiency
+  for(const g of allGains)g.efficiency=g.upgCost>0&&g.gain>0?g.gain/g.upgCost:0;
 
   // Compute max gain for bar scaling
   const maxGain=Math.max(1,...allGains.map(g=>g.gain));
@@ -898,10 +1011,13 @@ function budgetPlan(){
   const levels=upgrades.map(tier=>[...tier]);
   const ordered=[];
   const summary={};
+  // Use avgGain from current approxCache for indirect formulas
+  const cVals=Object.entries(approxCache).filter(([k,v])=>k!=='base'&&v>0).map(([,v])=>v);
+  const avgGain=cVals.length?cVals.reduce((a,b)=>a+b,0)/cVals.length:0;
   const MAX_ITER=600;
   for(let iter=0;iter<MAX_ITER;iter++){
     const{p:bp,e:be}=parseUpgrades(levels,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
-    const baseWave=analyticalSim(bp,be)[0];
+    const baseR=analyticalSim(bp,be);
     let bestGain=0,bestTi=-1,bestUj=-1,bestCost=0;
     for(let ti=0;ti<4;ti++){
       if(res[ti]<=0)continue;
@@ -913,7 +1029,7 @@ function budgetPlan(){
         if(lvl>=maxL)continue;
         const cost=costs[ti][uj]*Math.pow(1.25,lvl);
         if(cost>res[ti])continue;
-        const gain=computeGainFromLevels(ti,uj,levels,bp,be,baseWave);
+        const gain=computeGainFromLevels(ti,uj,levels,bp,be,baseR,avgGain);
         if(gain>bestGain){bestGain=gain;bestTi=ti;bestUj=uj;bestCost=cost}
       }
     }

--- a/index.html
+++ b/index.html
@@ -909,7 +909,7 @@ function renderPrestigeAdvice(){
   const wave=base[0];
   const next=PRESTIGE_MILESTONES.find(m=>m>prestigeCount);
   if(!next){
-    if(wave<250){const d=(250-wave).toFixed(1);el.textContent=`Farm to wave 250 for all rewards (need ${d} more waves)`;el.className='pres-advisor wait'}
+    if(wave<250){const d=(250-wave).toFixed(1);el.textContent=`Farm to wave 250 for last reward (need ${d} more waves)`;el.className='pres-advisor wait'}
     else{el.textContent='All rewards can be claimed.';el.className='pres-advisor done'}
     return;
   }

--- a/index.html
+++ b/index.html
@@ -502,14 +502,16 @@ function analyticalSim(player,enemy){
       const vHit=Math.max(0,eHit2-eHit*eHit);
       const enemyAtkSpd=enemy.atkSpeed+wave*0.02;
       const enemyHP=enemy.baseHealth+enemy.healthScaling*wave;
+      // Expected hitsToKill including player crits (not just raw atk)
+      const eHtkSub=Math.max(1,Math.ceil(enemyHP/epDmg));
       // Per-subzone hitsToKill variance (delta method, 1 encounter per subzone)
       const vHtk=epDmg4>0?enemyHP*enemyHP*vpDmg/epDmg4:0;
       const atkRatio=enemyAtkSpd/player.atkSpeed;
-      const timePerSub=(hitsToKill*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
+      const timePerSub=(eHtkSub*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
       // Iterate 5 subzones per wave
       for(let s=0;s<5;s++){
-        // Enemy hits this subzone (with remainder tracking across subzones)
-        const rawHits=remainder+hitsToKill*atkRatio;
+        // Enemy hits this subzone using crit-adjusted hitsToKill
+        const rawHits=remainder+eHtkSub*atkRatio;
         remainder=rawHits%1;
         const eHw=Math.floor(rawHits);
         // Variance from hitsToKill uncertainty: Var[hits] = Var[htk] * ratio^2

--- a/index.html
+++ b/index.html
@@ -462,7 +462,8 @@ function avgEvent_short(player,enemy){
 // Normal CDF via Hastings polynomial approximation (~700ns, 7.5e-8 accuracy)
 function Phi(z){if(z<-8)return 0;if(z>8)return 1;const t=1/(1+.2316419*Math.abs(z)),d=.3989423*Math.exp(-z*z/2),p=d*t*(.3193815+t*(-.3565638+t*(1.781478+t*(-1.821256+t*1.330274))));return z>0?1-p:p}
 // Analytical sim: returns [expectedWave, subzone, totalTime] using CLT-based survival probabilities.
-// Replaces mcGainForUpgrade for gain calculation - deterministic, no bias, ~0.3ms per call.
+// Iterates per SUBZONE (5 per wave) for intra-wave death resolution.
+// Metric matches FullEventSim.avgDistance: expectedSubzones/5 + 1.
 function analyticalSim(player,enemy){
   // Fast-path: 100% block = invincible
   if(player.blockChance>=1){
@@ -486,11 +487,10 @@ function analyticalSim(player,enemy){
   const vpDmg=Math.max(0,epDmg2-epDmg*epDmg);
   const epDmg4=epDmg*epDmg*epDmg*epDmg;
 
-  let cumE=0,cumVar=0,expectedWave=0,time=0,currentWave=1,remainder=0,dead=false;
+  let cumE=0,cumVar=0,expSub=0,time=0,currentWave=1,remainder=0,dead=false;
   for(let hitsToKill=1;hitsToKill<=10;hitsToKill++){
     const maxWaveForHits=get_highest_wave_killed_in_x_hits(player,enemy,hitsToKill);
     if(maxWaveForHits<currentWave)continue;
-    const timePerWave=5*(hitsToKill*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
     const topWave=Math.min(maxWaveForHits,MAX_WAVE);
     for(let wave=currentWave;wave<=topWave;wave++){
       // Enemy damage moments per hit at this wave
@@ -500,29 +500,39 @@ function analyticalSim(player,enemy){
       const eHit=(1-block)*baseDmg*(1+eCrit*(eCritMul-1));
       const eHit2=(1-block)*baseDmg*baseDmg*(1+eCrit*(eCritMul*eCritMul-1));
       const vHit=Math.max(0,eHit2-eHit*eHit);
-      // Expected enemy hits this wave (5 subzones, attack speed interleaving)
       const enemyAtkSpd=enemy.atkSpeed+wave*0.02;
-      const rawHits=remainder+hitsToKill*5*enemyAtkSpd/player.atkSpeed;
-      remainder=rawHits%1;
-      const eHw=Math.floor(rawHits);
-      // Player crit -> hitsToKill variance (delta method, 5 independent subzones)
       const enemyHP=enemy.baseHealth+enemy.healthScaling*wave;
-      const vHw=epDmg4>0?5*enemyHP*enemyHP*vpDmg/epDmg4:0;
-      // Accumulate (law of total variance)
-      cumE+=eHw*eHit;
-      cumVar+=eHw*vHit+vHw*eHit*eHit;
-      // Survival probability for this wave
-      let pSurv;
-      if(cumVar<=0)pSurv=hp>cumE?1:0;
-      else pSurv=Phi((hp-cumE)/Math.sqrt(cumVar));
-      expectedWave+=pSurv;
-      time+=timePerWave;
-      if(pSurv<1e-9){dead=true;break;}
+      // Per-subzone hitsToKill variance (delta method, 1 encounter per subzone)
+      const vHtk=epDmg4>0?enemyHP*enemyHP*vpDmg/epDmg4:0;
+      const atkRatio=enemyAtkSpd/player.atkSpeed;
+      const timePerSub=(hitsToKill*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
+      // Iterate 5 subzones per wave
+      for(let s=0;s<5;s++){
+        // Enemy hits this subzone (with remainder tracking across subzones)
+        const rawHits=remainder+hitsToKill*atkRatio;
+        remainder=rawHits%1;
+        const eHw=Math.floor(rawHits);
+        // Variance from hitsToKill uncertainty: Var[hits] = Var[htk] * ratio^2
+        const vHw=vHtk*atkRatio*atkRatio;
+        // Accumulate cumulative damage (law of total variance)
+        cumE+=eHw*eHit;
+        cumVar+=eHw*vHit+vHw*eHit*eHit;
+        // Survival probability after this subzone
+        let pSurv;
+        if(cumVar<=0)pSurv=hp>cumE?1:0;
+        else pSurv=Phi((hp-cumE)/Math.sqrt(cumVar));
+        expSub+=pSurv;
+        time+=timePerSub;
+        if(pSurv<1e-9){dead=true;break;}
+      }
+      if(dead)break;
     }
     if(dead)break;
     currentWave=topWave+1;
     if(currentWave>MAX_WAVE)break;
   }
+  // Convert subzones to FullEventSim-compatible metric: distance = subzones/5 + 1
+  const expectedWave=expSub/5+1;
   const frac=expectedWave-Math.floor(expectedWave);
   const sub=Math.max(1,Math.min(5,Math.round(frac*5)||1));
   return[expectedWave,sub,time];

--- a/index.html
+++ b/index.html
@@ -1001,9 +1001,10 @@ function refreshUpgradeValues(){
     document.getElementById(`upg-bm-${ti}-${uj}`).disabled=lvl<=0||locked;
     document.getElementById(`upg-bp-${ti}-${uj}`).disabled=lvl>=maxL||locked;
     const lockMsg=presReq>prestigeCount?`Unlocks at Prestige ${presReq}`:'Level Up Previous To Unlock';
-    document.getElementById(`upg-name-${ti}-${uj}`).textContent=locked?lockMsg:upgradeNames[ti][uj];
+    const nameStr=locked?lockMsg:capCount?`${upgradeNames[ti][uj]} (unlocks ${capCount})`:upgradeNames[ti][uj];
+    document.getElementById(`upg-name-${ti}-${uj}`).textContent=nameStr;
     document.getElementById(`upg-cost-${ti}-${uj}`).textContent=locked?'':formatNumber(costs[ti][uj]*Math.pow(1.25,lvl));
-    const gainStr=locked||lvl>=maxL||gain===0?'':gain>0.05?gain.toFixed(1)+(capCount?` (unlocks ${capCount})`:''): '< 0.1';
+    const gainStr=locked||lvl>=maxL||gain===0?'':gain>0.05?gain.toFixed(1):'< 0.1';
     document.getElementById(`upg-gain-${ti}-${uj}`).textContent=gainStr;
     const pct=gain>0?Math.max(4,Math.round(gain/maxGain*100)):0;
     document.getElementById(`upg-fill-${ti}-${uj}`).style.width=pct+'%';

--- a/index.html
+++ b/index.html
@@ -1146,10 +1146,12 @@ window.validateAnalyticalSim=function(mcRuns=10000){
     const{p,e}=parseUpgrades(upg,playerStatsBase,enemyStatsBase,pres,gem);
     const mc=FullEventSim(p,e,mcRuns);
     const an=analyticalSim(p,e);
+    const det=avgEvent_short(p,e);
+    const detWave=det[0]>0?det[0]+1-det[1]*0.2:0;
     const delta=Math.abs(an[0]-mc.avgDistance);
     const pass=delta<0.5;
-    results.push({label,analytical:an[0].toFixed(2),mc:mc.avgDistance.toFixed(2),delta:delta.toFixed(3),pass});
-    console.log(`${pass?'PASS':'FAIL'} ${label}: analytical=${an[0].toFixed(2)} mc=${mc.avgDistance.toFixed(2)} delta=${delta.toFixed(3)}`);
+    results.push({label,analytical:an[0].toFixed(2),det:detWave.toFixed(2),mc:mc.avgDistance.toFixed(2),delta:delta.toFixed(3),pass});
+    console.log(`${pass?'PASS':'FAIL'} ${label}: analytical=${an[0].toFixed(2)} det=${detWave.toFixed(2)} mc=${mc.avgDistance.toFixed(2)} delta=${delta.toFixed(3)}`);
   }
   const failures=results.filter(r=>!r.pass);
   console.log(`\n${results.length-failures.length}/${results.length} passed (threshold: <0.5 waves)`);

--- a/index.html
+++ b/index.html
@@ -459,6 +459,74 @@ function avgEvent_short(player,enemy){
   }
   return[finalWave,finalSub,totalTime];
 }
+// Normal CDF via Hastings polynomial approximation (~700ns, 7.5e-8 accuracy)
+function Phi(z){if(z<-8)return 0;if(z>8)return 1;const t=1/(1+.2316419*Math.abs(z)),d=.3989423*Math.exp(-z*z/2),p=d*t*(.3193815+t*(-.3565638+t*(1.781478+t*(-1.821256+t*1.330274))));return z>0?1-p:p}
+// Analytical sim: returns [expectedWave, subzone, totalTime] using CLT-based survival probabilities.
+// Replaces mcGainForUpgrade for gain calculation - deterministic, no bias, ~0.3ms per call.
+function analyticalSim(player,enemy){
+  // Fast-path: 100% block = invincible
+  if(player.blockChance>=1){
+    let time=0,cw=1;
+    for(let htk=1;htk<=10;htk++){
+      const mw=get_highest_wave_killed_in_x_hits(player,enemy,htk);
+      if(mw<cw)continue;
+      const top=Math.min(mw,MAX_WAVE);
+      time+=(top-cw+1)*5*(htk*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
+      cw=top+1;if(cw>MAX_WAVE)break;
+    }
+    return[MAX_WAVE,1,time];
+  }
+  const block=Math.min(Math.max(0,player.blockChance),0.9999);
+  const hp=player.health;
+  const pCrit=Math.max(0,player.crit)/100;
+  const pCritDmg=Math.max(1,player.critDmg);
+  // Player damage moments for hitsToKill variance (H6 fix)
+  const epDmg=player.atk*(1+pCrit*(pCritDmg-1));
+  const epDmg2=player.atk*player.atk*(1+pCrit*(pCritDmg*pCritDmg-1));
+  const vpDmg=Math.max(0,epDmg2-epDmg*epDmg);
+  const epDmg4=epDmg*epDmg*epDmg*epDmg;
+
+  let cumE=0,cumVar=0,expectedWave=0,time=0,currentWave=1,remainder=0,dead=false;
+  for(let hitsToKill=1;hitsToKill<=10;hitsToKill++){
+    const maxWaveForHits=get_highest_wave_killed_in_x_hits(player,enemy,hitsToKill);
+    if(maxWaveForHits<currentWave)continue;
+    const timePerWave=5*(hitsToKill*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
+    const topWave=Math.min(maxWaveForHits,MAX_WAVE);
+    for(let wave=currentWave;wave<=topWave;wave++){
+      // Enemy damage moments per hit at this wave
+      const baseDmg=Math.max(1,round(enemy.atk+wave*enemy.atkScaling));
+      const eCrit=Math.max(0,Math.min(1,(enemy.crit+wave)/100));
+      const eCritMul=Math.max(1,enemy.critDmg+wave*enemy.critDmgScaling);
+      const eHit=(1-block)*baseDmg*(1+eCrit*(eCritMul-1));
+      const eHit2=(1-block)*baseDmg*baseDmg*(1+eCrit*(eCritMul*eCritMul-1));
+      const vHit=Math.max(0,eHit2-eHit*eHit);
+      // Expected enemy hits this wave (5 subzones, attack speed interleaving)
+      const enemyAtkSpd=enemy.atkSpeed+wave*0.02;
+      const rawHits=remainder+hitsToKill*5*enemyAtkSpd/player.atkSpeed;
+      remainder=rawHits%1;
+      const eHw=Math.floor(rawHits);
+      // Player crit -> hitsToKill variance (delta method, 5 independent subzones)
+      const enemyHP=enemy.baseHealth+enemy.healthScaling*wave;
+      const vHw=epDmg4>0?5*enemyHP*enemyHP*vpDmg/epDmg4:0;
+      // Accumulate (law of total variance)
+      cumE+=eHw*eHit;
+      cumVar+=eHw*vHit+vHw*eHit*eHit;
+      // Survival probability for this wave
+      let pSurv;
+      if(cumVar<=0)pSurv=hp>cumE?1:0;
+      else pSurv=Phi((hp-cumE)/Math.sqrt(cumVar));
+      expectedWave+=pSurv;
+      time+=timePerWave;
+      if(pSurv<1e-9){dead=true;break;}
+    }
+    if(dead)break;
+    currentWave=topWave+1;
+    if(currentWave>MAX_WAVE)break;
+  }
+  const frac=expectedWave-Math.floor(expectedWave);
+  const sub=Math.max(1,Math.min(5,Math.round(frac*5)||1));
+  return[expectedWave,sub,time];
+}
 const GAIN_SIM_RUNS=200;
 // Monte Carlo fallback: 200 paired runs, returns gain in the current optimizeMode metric.
 // Called when deterministic sim shows 0 for non-offense upgrades (HP, speed, block, etc.).
@@ -1027,6 +1095,39 @@ function hideToast(){clearTimeout(_toastTimer);document.getElementById('toast').
 
 // ── BRAND SCROLL TO TOP ─────────────────────────────────────
 document.querySelector('.brand').addEventListener('click',()=>window.scrollTo({top:0,behavior:'smooth'}));
+
+// ── VALIDATION HARNESS ──────────────────────────────────────
+// Run in console: validateAnalyticalSim()
+window.validateAnalyticalSim=function(mcRuns=10000){
+  const states=[
+    // [upgrades, gemUp, prestigeCount, label]
+    [[[0,0,0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0]],[0,0,0,0],0,'Fresh start'],
+    [[[5,3,2,0,0,0,0,0,0,0],[0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0]],[0,0,0,0],0,'Early T1'],
+    [[[10,10,5,3,3,5,5,0,0,0],[5,3,3,2,3,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0]],[1,1,0,0],1,'P1 mid'],
+    [[[20,15,10,5,5,10,10,1,0,0],[10,5,5,5,10,0,0],[5,5,5,3,3,0,0,0],[3,3,3,3,3,0,0,0]],[2,2,0,0],3,'P3 mid-late'],
+    [[[30,25,15,10,10,15,15,2,2,10],[15,8,8,8,15,1,5],[10,10,10,5,5,1,3,10],[5,5,5,5,5,1,1,5]],[3,3,1,1],5,'P5 late'],
+    [[[40,40,20,15,15,20,20,3,3,20],[20,10,10,10,20,2,10],[15,15,15,10,8,2,5,20],[10,10,10,10,10,2,1,15]],[4,4,1,1],8,'P8 endgame'],
+    [[[10,0,0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0]],[0,0,0,0],0,'ATK-only'],
+    [[[0,20,0,0,0,0,0,0,0,0],[10,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,5,0,0,0,0,0,0]],[0,2,0,0],0,'HP-only'],
+    [[[5,5,5,0,0,5,5,0,0,0],[0,0,0,0,0,0,0],[0,0,5,0,0,0,0,0],[0,0,5,0,0,0,0,0]],[0,0,0,0],2,'Crit-heavy P2'],
+    [[[5,5,0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[10,0,0,0,0,0,0,0]],[0,0,0,0],1,'Block-heavy P1'],
+  ];
+  console.log(`Validating analyticalSim against FullEventSim(${mcRuns})...\n`);
+  const results=[];
+  for(const[upg,gem,pres,label]of states){
+    const{p,e}=parseUpgrades(upg,playerStatsBase,enemyStatsBase,pres,gem);
+    const mc=FullEventSim(p,e,mcRuns);
+    const an=analyticalSim(p,e);
+    const delta=Math.abs(an[0]-mc.avgDistance);
+    const pass=delta<0.5;
+    results.push({label,analytical:an[0].toFixed(2),mc:mc.avgDistance.toFixed(2),delta:delta.toFixed(3),pass});
+    console.log(`${pass?'PASS':'FAIL'} ${label}: analytical=${an[0].toFixed(2)} mc=${mc.avgDistance.toFixed(2)} delta=${delta.toFixed(3)}`);
+  }
+  const failures=results.filter(r=>!r.pass);
+  console.log(`\n${results.length-failures.length}/${results.length} passed (threshold: <0.5 waves)`);
+  if(failures.length>3)console.warn('GATE FAILED: >3 states diverge. Investigate before proceeding.');
+  return results;
+};
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -498,21 +498,10 @@ function analyticalSim(player,enemy){
     const vHit=Math.max(0,eHit2-eHit*eHit);
     const enemyAtkSpd=enemy.atkSpeed+wave*0.02;
     const enemyHP=enemy.baseHealth+enemy.healthScaling*wave;
-    // Expected hitsToKill via Phi summation: E[htk] = Σ P(htk > n)
-    // Corrects Jensen's inequality bias from ceil(HP/E[dmg]) >= E[ceil(HP/dmg)]
-    let eHtkSub=1,vHtk=0;
-    if(vpDmg>0){
-      let ehtk=1,ehtk2=1;// n=0: P(htk>0)=1, contributes 1 to E and 1 to E[X²]
-      for(let n=1;n<20;n++){
-        const pGt=Phi((enemyHP-n*epDmg)/Math.sqrt(n*vpDmg));
-        if(pGt<1e-9)break;
-        ehtk+=pGt;ehtk2+=(2*n+1)*pGt;
-      }
-      eHtkSub=Math.max(1,ehtk);
-      vHtk=Math.max(0,ehtk2-ehtk*ehtk);
-    }else{
-      eHtkSub=Math.max(1,Math.ceil(enemyHP/Math.max(1,epDmg)));
-    }
+    // Expected hitsToKill using average player damage (with crits)
+    const eHtkSub=Math.max(1,Math.ceil(enemyHP/epDmg));
+    // Variance from hitsToKill uncertainty (delta method)
+    const vHtk=epDmg4>0?enemyHP*enemyHP*vpDmg/epDmg4:0;
     const atkRatio=enemyAtkSpd/player.atkSpeed;
     const timePerSub=(eHtkSub*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
     let dead=false;

--- a/index.html
+++ b/index.html
@@ -461,6 +461,20 @@ function avgEvent_short(player,enemy){
 }
 // Normal CDF via Hastings polynomial approximation (~700ns, 7.5e-8 accuracy)
 function Phi(z){if(z<-8)return 0;if(z>8)return 1;const t=1/(1+.2316419*Math.abs(z)),d=.3989423*Math.exp(-z*z/2),p=d*t*(.3193815+t*(-.3565638+t*(1.781478+t*(-1.821256+t*1.330274))));return z>0?1-p:p}
+// Expected hitsToKill and variance via Phi summation (same technique as expected wave).
+// E[htk] = Σ P(htk > n) = 1 + Σ_{n=1} Φ((HP - n*E[dmg]) / sqrt(n*Var[dmg]))
+// Accounts for player crit reducing hitsToKill (Jensen's inequality correction).
+function expectedHtk(enemyHP,epDmg,vpDmg){
+  if(vpDmg<=0||epDmg<=0)return{e:Math.max(1,Math.ceil(enemyHP/Math.max(1,epDmg))),v:0};
+  let ehtk=0,ehtk2=0;
+  for(let n=0;n<30;n++){
+    const pGt=n===0?1:Phi((enemyHP-n*epDmg)/Math.sqrt(n*vpDmg));
+    if(pGt<1e-9)break;
+    ehtk+=pGt;
+    ehtk2+=(2*n+1)*pGt;
+  }
+  return{e:Math.max(1,ehtk),v:Math.max(0,ehtk2-ehtk*ehtk)};
+}
 // Analytical sim: returns [expectedWave, subzone, totalTime] using CLT-based survival probabilities.
 // Iterates per SUBZONE (5 per wave) for intra-wave death resolution.
 // Metric matches FullEventSim.avgDistance: expectedSubzones/5 + 1.
@@ -502,26 +516,9 @@ function analyticalSim(player,enemy){
       const vHit=Math.max(0,eHit2-eHit*eHit);
       const enemyAtkSpd=enemy.atkSpeed+wave*0.02;
       const enemyHP=enemy.baseHealth+enemy.healthScaling*wave;
-      // HitsToKill: use discrete distribution when possible, delta method otherwise
-      const minHtk=Math.max(1,Math.ceil(enemyHP/Math.max(1,player.atk*pCritDmg)));// best case (crit every hit)
-      const maxHtk=Math.max(1,Math.ceil(enemyHP/Math.max(1,player.atk)));// worst case (no crits)
-      let eHtkSub,vHtk;
-      if(minHtk===maxHtk){
-        // Deterministic: always same hitsToKill regardless of crits
-        eHtkSub=minHtk;vHtk=0;
-      }else if(maxHtk-minHtk<=2){
-        // Small range: compute exact discrete distribution
-        // P(htk=k) via cumulative crit probability for k hits
-        // Simplified: P(htk=minHtk) ≈ pCrit^(hits that need crit), else maxHtk
-        // For htk ∈ {n, n+1}: P(htk=n) = fraction of outcomes where crits suffice
-        const pLow=Math.min(1,Math.max(0,pCrit));// P(at least enough crits to kill in minHtk)
-        eHtkSub=minHtk*pLow+maxHtk*(1-pLow);
-        vHtk=pLow*(1-pLow)*(maxHtk-minHtk)*(maxHtk-minHtk);
-      }else{
-        // Large range: delta method
-        eHtkSub=Math.max(1,Math.ceil(enemyHP/epDmg));
-        vHtk=epDmg4>0?enemyHP*enemyHP*vpDmg/epDmg4:0;
-      }
+      // Expected hitsToKill via Phi summation (corrects Jensen's inequality bias)
+      const htk=expectedHtk(enemyHP,epDmg,vpDmg);
+      const eHtkSub=htk.e,vHtk=htk.v;
       const atkRatio=enemyAtkSpd/player.atkSpeed;
       const timePerSub=(eHtkSub*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
       // Iterate 5 subzones per wave

--- a/index.html
+++ b/index.html
@@ -910,7 +910,7 @@ function renderPrestigeAdvice(){
   const next=PRESTIGE_MILESTONES.find(m=>m>prestigeCount);
   if(!next){
     if(wave<250){const d=(250-wave).toFixed(1);el.textContent=`Farm to wave 250 for all rewards (need ${d} more waves)`;el.className='pres-advisor wait'}
-    else{el.textContent='All rewards claimed.';el.className='pres-advisor done'}
+    else{el.textContent='All rewards can be claimed.';el.className='pres-advisor done'}
     return;
   }
   const reqWave=next*5+5;

--- a/index.html
+++ b/index.html
@@ -62,11 +62,6 @@ body{background:var(--bg);color:var(--t1);font-family:'Space Mono',monospace;fon
 .help-btn{background:var(--s3);border:1px solid var(--b1);color:var(--t3);font-family:'Chakra Petch',sans-serif;font-size:var(--fs-micro);font-weight:700;width:19px;height:19px;line-height:16px;text-align:center;cursor:pointer;padding:0;flex-shrink:0;border-radius:3px;transition:color .15s,border-color .15s;margin-left:auto;position:relative}
 .help-btn::after{content:'';position:absolute;inset:-13px}
 @media(hover:hover){.help-btn:hover{color:var(--acc);border-color:var(--acc-dim)}}
-.opt-seg{display:inline-flex;margin-left:11px;border:1px solid var(--b1);border-radius:4px;overflow:hidden;vertical-align:middle}
-.opt-seg-btn{background:var(--s3);border:none;border-right:1px solid var(--b1);color:var(--t3);font-family:'Chakra Petch',sans-serif;font-size:var(--fs-micro);font-weight:700;padding:3px 9px;cursor:pointer;transition:color .15s,background-color .15s;letter-spacing:.06em;text-transform:uppercase}
-.opt-seg-btn:last-child{border-right:none}
-@media(hover:hover){.opt-seg-btn:hover:not(.active){color:var(--acc)}}
-.opt-seg-btn.active{background:var(--acc-dim);color:var(--acc)}
 .help-wrap{position:relative;display:inline}
 .help-popup{display:none;position:absolute;top:29px;left:0;background:var(--s1);border:1px solid var(--b2);padding:13px 16px;font-family:'Space Mono',monospace;font-size:var(--fs-sm);font-weight:400;color:var(--t2);line-height:1.5;letter-spacing:0;text-transform:none;max-width:399px;min-width:266px;z-index:20;white-space:normal}
 .help-popup.open{display:block}
@@ -216,7 +211,6 @@ body{background:var(--bg);color:var(--t1);font-family:'Space Mono',monospace;fon
 
 <header class="header">
   <h1 class="brand">⛏ OBELISK MINER EVENT SIM <span class="version">v2.4.0</span> <button class="help-btn" aria-label="Changelog" onclick="openChangelog()" style="margin-left:3px">?</button></h1>
-  <button class="res-btn" onclick="cycleResource()">Cycle Resource <span id="res-num">1</span> ▸</button>
   <button class="res-btn" id="btn-export" onclick="exportState()">Export ▾</button>
   <button class="res-btn" onclick="importState()">Import ▴</button>
   <a href="stargazing.html" class="res-btn" style="text-decoration:none;display:inline-block">Stargazing ★</a>
@@ -263,7 +257,7 @@ body{background:var(--bg);color:var(--t1);font-family:'Space Mono',monospace;fon
       <div class="sim-loading">Simulating…</div>
     </div>
     <div class="panel">
-      <div class="ptitle">Next Buy — best per tier <span class="opt-seg"><button class="opt-seg-btn active" id="opt-btn-rpm" onclick="setOptimizeMode('rpm')">res/min</button><button class="opt-seg-btn" id="opt-btn-wave" onclick="setOptimizeMode('wave')">max wave</button></span><span class="help-wrap"><button class="help-btn" aria-label="Help" onclick="toggleHelp(this)">?</button><div class="help-popup">Best upgrade per tier ranked by gain/cost efficiency. Click to buy +1 level (Shift+click for +10).<br><br><b>res/min:</b> ranks by farming speed - best when grinding resources.<br><b>max wave:</b> ranks by average wave reached - best when pushing for prestige/rewards. Attack damage is deprioritized once you already one-shot enemies; HP, block, and speed rise to the top.</div></span></div>
+      <div class="ptitle">Next Buy — best per tier <span class="help-wrap"><button class="help-btn" aria-label="Help" onclick="toggleHelp(this)">?</button><div class="help-popup">Best upgrade per tier ranked by wave gain per cost. Click to buy +1 level (Shift+click for +10).</div></span></div>
       <div id="top-picks"><div class="picks-empty">Calculating…</div></div>
     </div>
     <div class="panel">
@@ -541,51 +535,21 @@ function analyticalSim(player,enemy){
   const sub=Math.max(1,Math.min(5,Math.round(frac*5)||1));
   return[expectedWave,sub,time];
 }
-const GAIN_SIM_RUNS=200;
-// Monte Carlo fallback: 200 paired runs, returns gain in the current optimizeMode metric.
-// Called when deterministic sim shows 0 for non-offense upgrades (HP, speed, block, etc.).
-function mcGainForUpgrade(ti,uj){
-  const{p:bp,e:be}=parseUpgrades(upgrades,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
-  upgrades[ti][uj]=(upgrades[ti][uj]||0)+1;
-  const{p:up,e:ue}=parseUpgrades(upgrades,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
-  upgrades[ti][uj]--;
-  let baseTotal=0,upgTotal=0;
-  for(let i=0;i<GAIN_SIM_RUNS;i++){
-    const br=eventTest(bp,be),ur=eventTest(up,ue);
-    if(optimizeMode==='wave'){baseTotal+=br[0]+br[1]/5;upgTotal+=ur[0]+ur[1]/5;}
-    else{baseTotal+=resourcesPerMinute(br,currentResource,bp);upgTotal+=resourcesPerMinute(ur,currentResource,up);}
-  }
-  return Math.max(0,(upgTotal-baseTotal)/GAIN_SIM_RUNS);
-}
-// Compute gain for one upgrade (+1 level) against a base metric.
-// baseMetric = {rpm, wave} from the current base sim.
-// Handles offense-only filtering, mode branching, and MC fallback in one place.
-function computeUpgradeGain(ti,uj,p,e,base){
-  if(offenseOnly[ti][uj]&&get_highest_wave_killed_in_x_hits(p,e,1)>Math.floor(base.wave))return 0;
+// Compute wave gain for one upgrade (+1 level) using analyticalSim.
+function computeUpgradeGain(ti,uj,p,e,baseWave){
+  if(offenseOnly[ti][uj]&&get_highest_wave_killed_in_x_hits(p,e,1)>Math.floor(baseWave))return 0;
   upgrades[ti][uj]=(upgrades[ti][uj]||0)+1;
   const{p:pu,e:eu}=parseUpgrades(upgrades,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
   upgrades[ti][uj]--;
-  const det=avgEvent_short(pu,eu);
-  if(optimizeMode==='wave'){
-    const wGain=(det[0]+det[1]/5)-base.wave;
-    return wGain>0?wGain:mcGainForUpgrade(ti,uj);
-  }
-  const rpmGain=det[0]>0?resourcesPerMinute(det,currentResource,p)-base.rpm:0;
-  return rpmGain>0?rpmGain:mcGainForUpgrade(ti,uj);
+  return analyticalSim(pu,eu)[0]-baseWave;
 }
-// Budget planner variant: uses a local copy of levels instead of the global upgrades array.
-function computeGainFromLevels(ti,uj,levels,bp,be,base){
-  if(offenseOnly[ti][uj]&&get_highest_wave_killed_in_x_hits(bp,be,1)>Math.floor(base.wave))return 0;
+// Budget planner variant: uses local levels array instead of global upgrades.
+function computeGainFromLevels(ti,uj,levels,bp,be,baseWave){
+  if(offenseOnly[ti][uj]&&get_highest_wave_killed_in_x_hits(bp,be,1)>Math.floor(baseWave))return 0;
   levels[ti][uj]++;
   const{p,e}=parseUpgrades(levels,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
   levels[ti][uj]--;
-  const det=avgEvent_short(p,e);
-  if(optimizeMode==='wave'){
-    const wGain=(det[0]+det[1]/5)-base.wave;
-    return wGain>0?wGain:(approxCache[`${ti}_${uj}`]||0);
-  }
-  const rpmGain=det[0]>0?resourcesPerMinute(det,currentResource,bp)-base.rpm:0;
-  return rpmGain>0?rpmGain:(approxCache[`${ti}_${uj}`]||0);
+  return analyticalSim(p,e)[0]-baseWave;
 }
 
 // ── UI DATA ──────────────────────────────────────────────────
@@ -613,28 +577,15 @@ function formatNumber(n){
   const decimals=val>=100?0:val>=10?1:2;
   return val.toFixed(decimals)+suffixes[oom];
 }
-const resourceWaveReqs=[1,5,10,15]; // currency A every wave, B every 5th, C every 10th, D every 15th
-// Expected value of a random multiplier: chance c (0-1) of getting multiplier m, otherwise 1x
-function expectedMultiplier(c,m){return 1+c*(m-1)}
-// simResult = [finalWave, finalSub, totalTime] from avgEvent_short
-function resourcesPerMinute(simResult,resource,p){
-  if(!simResult||simResult[0]<0||simResult[2]<=0)return 0;
-  const res=resource||1,adj=res===1?(5-simResult[1])/5-1:0;
-  const avgWave=Math.floor((simResult[0]+adj)/resourceWaveReqs[res-1]);
-  if(avgWave<=0)return 0;
-  return(avgWave*avgWave+avgWave)*120/simResult[2]*expectedMultiplier((p.x5money||0)/100,5)*expectedMultiplier(p.x2money||0,2);
-}
 
 // ── PERSISTENCE ──────────────────────────────────────────────
 const LS_KEY='shminer_state';
-function saveState(){try{localStorage.setItem(LS_KEY,JSON.stringify({upgrades,gemUp,prestigeCount,baseCost,currentResource,optimizeMode}))}catch(_){}}
+function saveState(){try{localStorage.setItem(LS_KEY,JSON.stringify({upgrades,gemUp,prestigeCount,baseCost}))}catch(_){}}
 function applyStateFields(s){
   if(s.upgrades)upgrades=s.upgrades;
   if(s.gemUp)gemUp=s.gemUp;
   if(s.prestigeCount!=null)prestigeCount=s.prestigeCount;
   if(s.baseCost)baseCost=s.baseCost;
-  if(s.currentResource)currentResource=s.currentResource;
-  if(s.optimizeMode)optimizeMode=s.optimizeMode;
 }
 function loadState(){
   try{
@@ -645,7 +596,7 @@ function loadState(){
 
 // ── EXPORT / IMPORT ──────────────────────────────────────────
 function exportState(){
-  const data=JSON.stringify({upgrades,gemUp,prestigeCount,baseCost,currentResource});
+  const data=JSON.stringify({upgrades,gemUp,prestigeCount,baseCost});
   navigator.clipboard.writeText(data).then(()=>{
     const btn=document.getElementById('btn-export');
     const orig=btn.textContent;btn.textContent='Copied!';
@@ -660,8 +611,7 @@ function applyImport(text){
   try{
     const s=JSON.parse(text);
     if(!Array.isArray(s.upgrades)||s.upgrades.length!==4||!Array.isArray(s.gemUp)||s.gemUp.length!==4
-      ||typeof s.prestigeCount!=='number'||!Array.isArray(s.baseCost)||s.baseCost.length!==4
-      ||typeof s.currentResource!=='number'||s.currentResource<1||s.currentResource>4)
+      ||typeof s.prestigeCount!=='number'||!Array.isArray(s.baseCost)||s.baseCost.length!==4)
       throw new Error('invalid shape');
     applyStateFields(s);
     approxCache={};saveState();runAndRender();
@@ -680,8 +630,7 @@ function stopHold(){
 }
 
 // ── UI STATE ─────────────────────────────────────────────────
-let currentResource=1,baseCost=[0,0,0,0],approxCache={},cachedP=null,cachedE=null,shiftHeld=false;
-let optimizeMode='rpm'; // 'rpm' | 'wave'
+let baseCost=[0,0,0,0],approxCache={},cachedP=null,cachedE=null,shiftHeld=false;
 document.addEventListener('keydown',e=>{if(e.key==='Shift')shiftHeld=true});
 document.addEventListener('keyup',  e=>{if(e.key==='Shift')shiftHeld=false});
 
@@ -697,13 +646,6 @@ function prestigeReset(){
   for(let ti=0;ti<4;ti++)for(let uj=0;uj<upgrades[ti].length;uj++)upgrades[ti][uj]=0;
   approxCache={};runAndRender();
   showToast('Upgrades reset',()=>{for(let ti=0;ti<4;ti++)upgrades[ti]=[...prev[ti]];approxCache={};runAndRender()});
-}
-function cycleResource(){currentResource=(currentResource%4)+1;document.getElementById('res-num').textContent=currentResource;saveState();refreshUpgradeValues()}
-function setOptimizeMode(mode){
-  optimizeMode=mode;
-  document.getElementById('opt-btn-rpm').classList.toggle('active',mode==='rpm');
-  document.getElementById('opt-btn-wave').classList.toggle('active',mode==='wave');
-  approxCache={};saveState();refreshUpgradeValues();
 }
 function setUpgrade(ti,uj,val){upgrades[ti][uj]=Math.max(0,Math.min(currentMaxLvl(ti,uj),parseInt(val)||0));approxCache={};runAndRender()}
 function changeUpgrade(ti,uj,delta){
@@ -823,10 +765,8 @@ function buildUpgradesDOM(){
 }
 
 function refreshUpgradeValues(){
-  if(!approxCache['base']){
-    const baseSim=avgEvent_short(cachedP||playerStatsBase,cachedE||enemyStatsBase);
-    approxCache['base']={rpm:resourcesPerMinute(baseSim,currentResource,cachedP||playerStatsBase),wave:baseSim[0]+baseSim[1]/5};
-  }
+  if(!approxCache['base'])
+    approxCache['base']=analyticalSim(cachedP||playerStatsBase,cachedE||enemyStatsBase)[0];
   const base=approxCache['base'];
 
   // First pass: collect all gains
@@ -897,7 +837,7 @@ function refreshUpgradeValues(){
       </div>
       <div class="pick-right">
         <div class="pick-gain">${gainText}</div>
-        <div class="pick-cost">${optimizeMode==='wave'?'avg wave':`res${currentResource}/min`}</div>
+        <div class="pick-cost">avg wave</div>
       </div>
     </div>`;
   }).join('');
@@ -961,8 +901,7 @@ function budgetPlan(){
   const MAX_ITER=600;
   for(let iter=0;iter<MAX_ITER;iter++){
     const{p:bp,e:be}=parseUpgrades(levels,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
-    const bApx=avgEvent_short(bp,be);
-    const base={rpm:resourcesPerMinute(bApx,currentResource,bp),wave:bApx[0]+bApx[1]/5};
+    const baseWave=analyticalSim(bp,be)[0];
     let bestGain=0,bestTi=-1,bestUj=-1,bestCost=0;
     for(let ti=0;ti<4;ti++){
       if(res[ti]<=0)continue;
@@ -974,7 +913,7 @@ function budgetPlan(){
         if(lvl>=maxL)continue;
         const cost=costs[ti][uj]*Math.pow(1.25,lvl);
         if(cost>res[ti])continue;
-        const gain=computeGainFromLevels(ti,uj,levels,bp,be,base);
+        const gain=computeGainFromLevels(ti,uj,levels,bp,be,baseWave);
         if(gain>bestGain){bestGain=gain;bestTi=ti;bestUj=uj;bestCost=cost}
       }
     }
@@ -1029,7 +968,6 @@ function runAndRender(){
   refreshUpgradeValues();
   renderPrestigeMilestone();
   document.getElementById('pres-input').value=prestigeCount;
-  document.getElementById('res-num').textContent=currentResource;
   saveState();
 }
 
@@ -1079,8 +1017,6 @@ function dismissOnboard(){document.getElementById('onboard-banner').style.displa
 loadState();
 buildUpgradesDOM();
 buildGemsDOM();
-// Sync opt-seg button state after loadState
-(function(){document.getElementById('opt-btn-rpm').classList.toggle('active',optimizeMode==='rpm');document.getElementById('opt-btn-wave').classList.toggle('active',optimizeMode==='wave');})();
 runAndRender();
 showOnboard();
 

--- a/index.html
+++ b/index.html
@@ -1094,14 +1094,14 @@ function budgetPlan(){
   const levels=upgrades.map(tier=>[...tier]);
   const ordered=[];
   const summary={};
-  // Use avgGain from current approxCache for indirect formulas
   const cVals=Object.entries(approxCache).filter(([k,v])=>k!=='base'&&v>0).map(([,v])=>v);
   const avgGain=cVals.length?cVals.reduce((a,b)=>a+b,0)/cVals.length:0;
-  const MAX_ITER=600;
+  const MAX_ITER=600,LOOKAHEAD=20;
   for(let iter=0;iter<MAX_ITER;iter++){
     const{p:bp,e:be}=parseUpgrades(levels,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
     const baseR=analyticalSim(bp,be);
-    let bestGain=0,bestTi=-1,bestUj=-1,bestCost=0;
+    // Single-step scan
+    const cands=[];
     for(let ti=0;ti<4;ti++){
       if(res[ti]<=0)continue;
       for(let uj=0;uj<upgradeNames[ti].length;uj++){
@@ -1113,16 +1113,50 @@ function budgetPlan(){
         const cost=costs[ti][uj]*Math.pow(1.25,lvl);
         if(cost>res[ti])continue;
         const gain=computeGainFromLevels(ti,uj,levels,bp,be,baseR,avgGain);
-        if(gain>bestGain){bestGain=gain;bestTi=ti;bestUj=uj;bestCost=cost}
+        if(gain>0)cands.push({ti,uj,gain,cost});
       }
     }
-    if(bestTi===-1)break;
-    levels[bestTi][bestUj]=(levels[bestTi][bestUj]||0)+1;
-    res[bestTi]-=bestCost;
-    const key=`${bestTi}_${bestUj}`;
-    if(!summary[key]){summary[key]={ti:bestTi,uj:bestUj,count:0,totalCost:0,startLvl:upgrades[bestTi][bestUj]||0};ordered.push(key)}
+    if(!cands.length)break;
+    cands.sort((a,b)=>b.gain-a.gain);
+    let pick=cands[0];
+    // 2-step lookahead (first LOOKAHEAD iterations, >1 candidate, greedy not dominant)
+    if(iter<LOOKAHEAD&&cands.length>1&&cands[0].gain<=cands[1].gain*3){
+      const top=cands.slice(0,5);
+      let greedyTotal=0,bestAlt=null,bestAltTotal=-1;
+      for(const c of top){
+        levels[c.ti][c.uj]=(levels[c.ti][c.uj]||0)+1;
+        const savedR=res[c.ti];res[c.ti]-=c.cost;
+        const{p:sp,e:se}=parseUpgrades(levels,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
+        const newBase=analyticalSim(sp,se);
+        let bfGain=0;
+        for(let ti=0;ti<4;ti++){
+          if(res[ti]<=0)continue;
+          for(let uj=0;uj<upgradeNames[ti].length;uj++){
+            const lv2=levels[ti][uj]||0;
+            if(prestigeUnlocked[ti][uj]>prestigeCount)continue;
+            if(uj>0&&(levels[ti][uj-1]||0)<1)continue;
+            if(lv2>=maxLvlFromLevels(ti,uj,levels))continue;
+            const c2=costs[ti][uj]*Math.pow(1.25,lv2);
+            if(c2>res[ti])continue;
+            const g=computeGainFromLevels(ti,uj,levels,sp,se,newBase,avgGain);
+            if(g>bfGain)bfGain=g;
+          }
+        }
+        levels[c.ti][c.uj]--;
+        res[c.ti]=savedR;
+        const total=c.gain+bfGain;
+        if(c===cands[0])greedyTotal=total;
+        else if(total>bestAltTotal){bestAltTotal=total;bestAlt=c}
+      }
+      if(bestAlt&&bestAltTotal>greedyTotal*1.05)pick=bestAlt;
+    }
+    // Buy
+    levels[pick.ti][pick.uj]=(levels[pick.ti][pick.uj]||0)+1;
+    res[pick.ti]-=pick.cost;
+    const key=`${pick.ti}_${pick.uj}`;
+    if(!summary[key]){summary[key]={ti:pick.ti,uj:pick.uj,count:0,totalCost:0,startLvl:upgrades[pick.ti][pick.uj]||0};ordered.push(key)}
     summary[key].count++;
-    summary[key].totalCost+=bestCost;
+    summary[key].totalCost+=pick.cost;
   }
   renderBudgetResults(ordered,summary,res);
 }
@@ -1148,6 +1182,77 @@ function budgetBuy(ti,uj,targetLvl,totalCost){
   inp.value=formatNumber(Math.max(0,Math.round(current-totalCost)));
   approxCache={};runAndRender();budgetPlan();
 }
+// Validation harness: compare greedy vs 2-step lookahead budget strategies.
+// Usage: compareBudgetStrategies([10000,10000,10000,10000])
+window.compareBudgetStrategies=function(budgets){
+  function runStrategy(useLookahead){
+    const res=budgets.slice();
+    const lv=upgrades.map(tier=>[...tier]);
+    const cVals=Object.entries(approxCache).filter(([k,v])=>k!=='base'&&v>0).map(([,v])=>v);
+    const avg=cVals.length?cVals.reduce((a,b)=>a+b,0)/cVals.length:0;
+    let iters=0,overrides=0;
+    const t0=performance.now();
+    for(let iter=0;iter<600;iter++){
+      const{p:bp,e:be}=parseUpgrades(lv,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
+      const baseR=analyticalSim(bp,be);
+      const cands=[];
+      for(let ti=0;ti<4;ti++){
+        if(res[ti]<=0)continue;
+        for(let uj=0;uj<upgradeNames[ti].length;uj++){
+          const lvl=lv[ti][uj]||0,maxL=maxLvlFromLevels(ti,uj,lv);
+          if(prestigeUnlocked[ti][uj]>prestigeCount)continue;
+          if(uj>0&&(lv[ti][uj-1]||0)<1)continue;
+          if(lvl>=maxL)continue;
+          const cost=costs[ti][uj]*Math.pow(1.25,lvl);
+          if(cost>res[ti])continue;
+          const gain=computeGainFromLevels(ti,uj,lv,bp,be,baseR,avg);
+          if(gain>0)cands.push({ti,uj,gain,cost});
+        }
+      }
+      if(!cands.length)break;
+      cands.sort((a,b)=>b.gain-a.gain);
+      let pick=cands[0];
+      if(useLookahead&&iter<20&&cands.length>1&&cands[0].gain<=cands[1].gain*3){
+        const top=cands.slice(0,5);
+        let greedyTotal=0,bestAlt=null,bestAltTotal=-1;
+        for(const c of top){
+          lv[c.ti][c.uj]=(lv[c.ti][c.uj]||0)+1;
+          const savedR=res[c.ti];res[c.ti]-=c.cost;
+          const{p:sp,e:se}=parseUpgrades(lv,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
+          const nb=analyticalSim(sp,se);
+          let bf=0;
+          for(let ti=0;ti<4;ti++){
+            if(res[ti]<=0)continue;
+            for(let uj=0;uj<upgradeNames[ti].length;uj++){
+              const l2=lv[ti][uj]||0;
+              if(prestigeUnlocked[ti][uj]>prestigeCount)continue;
+              if(uj>0&&(lv[ti][uj-1]||0)<1)continue;
+              if(l2>=maxLvlFromLevels(ti,uj,lv))continue;
+              const c2=costs[ti][uj]*Math.pow(1.25,l2);
+              if(c2>res[ti])continue;
+              const g=computeGainFromLevels(ti,uj,lv,sp,se,nb,avg);
+              if(g>bf)bf=g;
+            }
+          }
+          lv[c.ti][c.uj]--;
+          res[c.ti]=savedR;
+          const total=c.gain+bf;
+          if(c===cands[0])greedyTotal=total;
+          else if(total>bestAltTotal){bestAltTotal=total;bestAlt=c}
+        }
+        if(bestAlt&&bestAltTotal>greedyTotal*1.05){pick=bestAlt;overrides++}
+      }
+      lv[pick.ti][pick.uj]=(lv[pick.ti][pick.uj]||0)+1;
+      res[pick.ti]-=pick.cost;
+      iters++;
+    }
+    const{p,e}=parseUpgrades(lv,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
+    const wave=analyticalSim(p,e)[0];
+    return{wave:+wave.toFixed(2),iters,overrides,ms:Math.round(performance.now()-t0)};
+  }
+  const g=runStrategy(false),l=runStrategy(true);
+  console.table({greedy:g,lookahead:l,delta:{wave:+(l.wave-g.wave).toFixed(2),overrides:l.overrides,extraMs:l.ms-g.ms}});
+};
 
 function runAndRender(){
   const{p,e}=parseUpgrades(upgrades,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);

--- a/index.html
+++ b/index.html
@@ -502,10 +502,26 @@ function analyticalSim(player,enemy){
       const vHit=Math.max(0,eHit2-eHit*eHit);
       const enemyAtkSpd=enemy.atkSpeed+wave*0.02;
       const enemyHP=enemy.baseHealth+enemy.healthScaling*wave;
-      // Expected hitsToKill including player crits (not just raw atk)
-      const eHtkSub=Math.max(1,Math.ceil(enemyHP/epDmg));
-      // Per-subzone hitsToKill variance (delta method, 1 encounter per subzone)
-      const vHtk=epDmg4>0?enemyHP*enemyHP*vpDmg/epDmg4:0;
+      // HitsToKill: use discrete distribution when possible, delta method otherwise
+      const minHtk=Math.max(1,Math.ceil(enemyHP/Math.max(1,player.atk*pCritDmg)));// best case (crit every hit)
+      const maxHtk=Math.max(1,Math.ceil(enemyHP/Math.max(1,player.atk)));// worst case (no crits)
+      let eHtkSub,vHtk;
+      if(minHtk===maxHtk){
+        // Deterministic: always same hitsToKill regardless of crits
+        eHtkSub=minHtk;vHtk=0;
+      }else if(maxHtk-minHtk<=2){
+        // Small range: compute exact discrete distribution
+        // P(htk=k) via cumulative crit probability for k hits
+        // Simplified: P(htk=minHtk) ≈ pCrit^(hits that need crit), else maxHtk
+        // For htk ∈ {n, n+1}: P(htk=n) = fraction of outcomes where crits suffice
+        const pLow=Math.min(1,Math.max(0,pCrit));// P(at least enough crits to kill in minHtk)
+        eHtkSub=minHtk*pLow+maxHtk*(1-pLow);
+        vHtk=pLow*(1-pLow)*(maxHtk-minHtk)*(maxHtk-minHtk);
+      }else{
+        // Large range: delta method
+        eHtkSub=Math.max(1,Math.ceil(enemyHP/epDmg));
+        vHtk=epDmg4>0?enemyHP*enemyHP*vpDmg/epDmg4:0;
+      }
       const atkRatio=enemyAtkSpd/player.atkSpeed;
       const timePerSub=(eHtkSub*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
       // Iterate 5 subzones per wave

--- a/index.html
+++ b/index.html
@@ -555,7 +555,11 @@ function analyticalSim(player,enemy){
 // avgGain = mean of positive combat gains (for indirect value formulas; 0 during pass 1).
 function computeUpgradeGain(ti,uj,p,e,baseR,avgGain){
   const type=upgradeType[ti][uj];
-  if(type==='cap')return 0;
+  if(type==='cap'){
+    if(!avgGain)return 0;
+    if(ti===3&&uj===CAP_OF_CAPS_IDX)return computeCapOfCapsCompoundGain(baseR,avgGain);
+    return computeCapCompoundGain(ti,uj,baseR,avgGain);
+  }
   if(offenseOnly[ti][uj]&&get_highest_wave_killed_in_x_hits(p,e,1)>Math.floor(baseR[0]))return 0;
   if(type==='speed'){
     if(!avgGain)return 0; // pass 1: skip
@@ -601,10 +605,50 @@ function computeUpgradeGain(ti,uj,p,e,baseR,avgGain){
   upgrades[ti][uj]--;
   return analyticalSim(pu,eu)[0]-baseR[0];
 }
+// Cap compound gain: sum of wave gains from each maxed upgrade that +1 cap unlocks.
+function computeCapCompoundGain(ti,uj,baseR,avgGain){
+  const maxedUpgs=[];
+  for(let u=0;u<upgradeNames[ti].length;u++){
+    if(u!==uj&&(upgrades[ti][u]||0)>=currentMaxLvl(ti,u))maxedUpgs.push(u);
+  }
+  if(!maxedUpgs.length)return 0;
+  upgrades[ti][uj]=(upgrades[ti][uj]||0)+1;
+  let compound=0;
+  for(const u of maxedUpgs){
+    // Only count if cap+1 actually raised this upgrade's max level
+    if((upgrades[ti][u]||0)<currentMaxLvl(ti,u))
+      compound+=computeUpgradeGain(ti,u,cachedP,cachedE,baseR,avgGain);
+  }
+  upgrades[ti][uj]--;
+  return compound;
+}
+// Cap of Caps (T4[6]): cascade depth=2. Unlocks cap upgrades, which unlock regular upgrades.
+function computeCapOfCapsCompoundGain(baseR,avgGain){
+  const maxedCaps=[];
+  for(let t=0;t<4;t++){
+    const ci=capUpgIdx[t];
+    if((upgrades[t][ci]||0)>=currentMaxLvl(t,ci))maxedCaps.push(t);
+  }
+  if(!maxedCaps.length)return 0;
+  upgrades[3][CAP_OF_CAPS_IDX]=(upgrades[3][CAP_OF_CAPS_IDX]||0)+1;
+  let compound=0;
+  for(const t of maxedCaps){
+    const ci=capUpgIdx[t];
+    // Only count if cap-of-caps+1 actually raised this cap's max level
+    if((upgrades[t][ci]||0)<currentMaxLvl(t,ci))
+      compound+=computeCapCompoundGain(t,ci,baseR,avgGain);
+  }
+  upgrades[3][CAP_OF_CAPS_IDX]--;
+  return compound;
+}
 // Budget planner variant: uses local levels array instead of global upgrades.
 function computeGainFromLevels(ti,uj,levels,bp,be,baseR,avgGain){
   const type=upgradeType[ti][uj];
-  if(type==='cap')return 0;
+  if(type==='cap'){
+    if(!avgGain)return 0;
+    if(ti===3&&uj===CAP_OF_CAPS_IDX)return computeCapOfCapsCompoundFromLevels(levels,bp,be,baseR,avgGain);
+    return computeCapCompoundGainFromLevels(ti,uj,levels,bp,be,baseR,avgGain);
+  }
   if(offenseOnly[ti][uj]&&get_highest_wave_killed_in_x_hits(bp,be,1)>Math.floor(baseR[0]))return 0;
   if(type==='speed'){
     if(!avgGain)return 0;
@@ -646,6 +690,39 @@ function computeGainFromLevels(ti,uj,levels,bp,be,baseR,avgGain){
   const{p,e}=parseUpgrades(levels,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
   levels[ti][uj]--;
   return analyticalSim(p,e)[0]-baseR[0];
+}
+// Budget planner cap compound gain variants (use local levels array).
+function computeCapCompoundGainFromLevels(ti,uj,levels,bp,be,baseR,avgGain){
+  const maxedUpgs=[];
+  for(let u=0;u<upgradeNames[ti].length;u++){
+    if(u!==uj&&(levels[ti][u]||0)>=maxLvlFromLevels(ti,u,levels))maxedUpgs.push(u);
+  }
+  if(!maxedUpgs.length)return 0;
+  levels[ti][uj]=(levels[ti][uj]||0)+1;
+  let compound=0;
+  for(const u of maxedUpgs){
+    if((levels[ti][u]||0)<maxLvlFromLevels(ti,u,levels))
+      compound+=computeGainFromLevels(ti,u,levels,bp,be,baseR,avgGain);
+  }
+  levels[ti][uj]--;
+  return compound;
+}
+function computeCapOfCapsCompoundFromLevels(levels,bp,be,baseR,avgGain){
+  const maxedCaps=[];
+  for(let t=0;t<4;t++){
+    const ci=capUpgIdx[t];
+    if((levels[t][ci]||0)>=maxLvlFromLevels(t,ci,levels))maxedCaps.push(t);
+  }
+  if(!maxedCaps.length)return 0;
+  levels[3][CAP_OF_CAPS_IDX]=(levels[3][CAP_OF_CAPS_IDX]||0)+1;
+  let compound=0;
+  for(const t of maxedCaps){
+    const ci=capUpgIdx[t];
+    if((levels[t][ci]||0)<maxLvlFromLevels(t,ci,levels))
+      compound+=computeCapCompoundGainFromLevels(t,ci,levels,bp,be,baseR,avgGain);
+  }
+  levels[3][CAP_OF_CAPS_IDX]--;
+  return compound;
 }
 
 // ── UI DATA ──────────────────────────────────────────────────
@@ -874,10 +951,15 @@ function refreshUpgradeValues(){
       const locked=presReq>prestigeCount||needsPrev;
       const maxL=currentMaxLvl(ti,uj),lvl=upgrades[ti][uj]||0;
       const isCap=capUpgIdx[ti]===uj||(ti===3&&uj===CAP_OF_CAPS_IDX);
-      let capUseful=false;
-      if(isCap){for(let u=0;u<upgradeNames[ti].length;u++){if(u!==uj&&(upgrades[ti][u]||0)>=currentMaxLvl(ti,u)){capUseful=true;break}}}
+      let capUseful=false,capCount=0;
+      if(isCap&&ti===3&&uj===CAP_OF_CAPS_IDX){
+        // Cap of Caps: check if any tier's cap upgrade is at max
+        for(let t=0;t<4;t++){const ci=capUpgIdx[t];if((upgrades[t][ci]||0)>=currentMaxLvl(t,ci)){capUseful=true;capCount++}}
+      }else if(isCap){
+        for(let u=0;u<upgradeNames[ti].length;u++){if(u!==uj&&(upgrades[ti][u]||0)>=currentMaxLvl(ti,u)){capUseful=true;capCount++}}
+      }
       const canEval=!locked&&cachedP&&lvl<maxL&&(!isCap||capUseful);
-      allGains.push({ti,uj,gain:0,efficiency:0,upgCost:locked||lvl>=maxL?0:costs[ti][uj]*Math.pow(1.25,lvl),locked,needsPrev,lvl,maxL,presReq,canEval});
+      allGains.push({ti,uj,gain:0,efficiency:0,upgCost:locked||lvl>=maxL?0:costs[ti][uj]*Math.pow(1.25,lvl),locked,needsPrev,lvl,maxL,presReq,canEval,capCount});
     }
   }
   // Pass 1: combat + prestige (P>0) gains
@@ -897,7 +979,7 @@ function refreshUpgradeValues(){
   for(const g of allGains){
     if(!g.canEval||g.gain>0)continue;
     const type=upgradeType[g.ti][g.uj];
-    if(type==='speed'||type==='resource'||type==='mixed'||(type==='prestige'&&prestigeCount===0)){
+    if(type==='speed'||type==='resource'||type==='mixed'||type==='cap'||(type==='prestige'&&prestigeCount===0)){
       const key=`${g.ti}_${g.uj}`;
       if(!approxCache[key])approxCache[key]=computeUpgradeGain(g.ti,g.uj,cachedP,cachedE,baseR,avgGain);
       g.gain=approxCache[key];
@@ -910,7 +992,7 @@ function refreshUpgradeValues(){
   const maxGain=Math.max(1,...allGains.map(g=>g.gain));
 
   // Second pass: update DOM
-  for(const{ti,uj,gain,locked,needsPrev,lvl,maxL,presReq}of allGains){
+  for(const{ti,uj,gain,locked,needsPrev,lvl,maxL,presReq,capCount}of allGains){
     const maxed=!locked&&lvl>=maxL;
     document.getElementById(`upg-row-${ti}-${uj}`).className=`upg-row${locked?' locked':maxed?' maxed':''}`;
     const inp=document.getElementById(`upg-inp-${ti}-${uj}`);
@@ -921,7 +1003,7 @@ function refreshUpgradeValues(){
     const lockMsg=presReq>prestigeCount?`Unlocks at Prestige ${presReq}`:'Level Up Previous To Unlock';
     document.getElementById(`upg-name-${ti}-${uj}`).textContent=locked?lockMsg:upgradeNames[ti][uj];
     document.getElementById(`upg-cost-${ti}-${uj}`).textContent=locked?'':formatNumber(costs[ti][uj]*Math.pow(1.25,lvl));
-    const gainStr=locked||lvl>=maxL||gain===0?'':gain>0.05?gain.toFixed(1):'< 0.1';
+    const gainStr=locked||lvl>=maxL||gain===0?'':gain>0.05?gain.toFixed(1)+(capCount?` (unlocks ${capCount})`:''): '< 0.1';
     document.getElementById(`upg-gain-${ti}-${uj}`).textContent=gainStr;
     const pct=gain>0?Math.max(4,Math.round(gain/maxGain*100)):0;
     document.getElementById(`upg-fill-${ti}-${uj}`).style.width=pct+'%';
@@ -1194,6 +1276,35 @@ window.validateAnalyticalSim=function(mcRuns=10000){
   const failures=results.filter(r=>!r.pass);
   console.log(`\n${results.length-failures.length}/${results.length} passed (threshold: <0.5 waves)`);
   if(failures.length>3)console.warn('GATE FAILED: >3 states diverge. Investigate before proceeding.');
+
+  // Cap compound gain sanity check
+  console.log('\n--- Cap compound gain ---');
+  // State: T1 upgrades at max (base max=50 for T1[0], T1[1])
+  const capUpg=[[50,50,25,25,25,25,25,0,0,0],[0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0]];
+  const capGem=[0,0,0,0];
+  const savedUpg=upgrades.map(t=>[...t]);const savedP=prestigeCount;
+  for(let t=0;t<4;t++)for(let u=0;u<capUpg[t].length;u++)upgrades[t][u]=capUpg[t][u];
+  prestigeCount=0;
+  const{p:cp,e:ce}=parseUpgrades(upgrades,playerStatsBase,enemyStatsBase,prestigeCount,capGem);
+  cachedP=cp;cachedE=ce;
+  const capBaseR=analyticalSim(cp,ce);
+  // Compute avgGain from combat upgrades (simplified: just pick a few)
+  const sampleGains=[];
+  for(let u=0;u<7;u++){
+    if(upgradeType[0][u]==='combat'&&upgrades[0][u]<currentMaxLvl(0,u)){
+      sampleGains.push(computeUpgradeGain(0,u,cp,ce,capBaseR,0));
+    }
+  }
+  const capAvgGain=sampleGains.length?sampleGains.filter(g=>g>0).reduce((s,g)=>s+g,0)/Math.max(1,sampleGains.filter(g=>g>0).length):0;
+  const capGain=computeCapCompoundGain(0,7,capBaseR,capAvgGain);
+  console.log(`T1 cap (T1[7]) with ${capUpg[0].filter((v,i)=>i!==7&&v>=maxLevels[0][i]).length} maxed: compound gain = ${capGain.toFixed(3)}`);
+  console.log(capGain>0?'PASS: cap compound gain > 0':'FAIL: cap compound gain should be > 0');
+  // Restore
+  for(let t=0;t<4;t++)for(let u=0;u<savedUpg[t].length;u++)upgrades[t][u]=savedUpg[t][u];
+  prestigeCount=savedP;
+  const{p:rp,e:re}=parseUpgrades(upgrades,playerStatsBase,enemyStatsBase,prestigeCount,gemUp);
+  cachedP=rp;cachedE=re;
+
   return results;
 };
 </script>

--- a/index.html
+++ b/index.html
@@ -461,20 +461,8 @@ function avgEvent_short(player,enemy){
 }
 // Normal CDF via Hastings polynomial approximation (~700ns, 7.5e-8 accuracy)
 function Phi(z){if(z<-8)return 0;if(z>8)return 1;const t=1/(1+.2316419*Math.abs(z)),d=.3989423*Math.exp(-z*z/2),p=d*t*(.3193815+t*(-.3565638+t*(1.781478+t*(-1.821256+t*1.330274))));return z>0?1-p:p}
-// Expected hitsToKill and variance via Phi summation (same technique as expected wave).
-// E[htk] = Σ P(htk > n) = 1 + Σ_{n=1} Φ((HP - n*E[dmg]) / sqrt(n*Var[dmg]))
-// Accounts for player crit reducing hitsToKill (Jensen's inequality correction).
-function expectedHtk(enemyHP,epDmg,vpDmg){
-  if(vpDmg<=0||epDmg<=0)return{e:Math.max(1,Math.ceil(enemyHP/Math.max(1,epDmg))),v:0};
-  let ehtk=0,ehtk2=0;
-  for(let n=0;n<30;n++){
-    const pGt=n===0?1:Phi((enemyHP-n*epDmg)/Math.sqrt(n*vpDmg));
-    if(pGt<1e-9)break;
-    ehtk+=pGt;
-    ehtk2+=(2*n+1)*pGt;
-  }
-  return{e:Math.max(1,ehtk),v:Math.max(0,ehtk2-ehtk*ehtk)};
-}
+// Like get_highest_wave_killed_in_x_hits but using expected player damage (with crits)
+function get_highest_wave_killed_in_x_hits_expected(epDmg,enemy,hits){return Math.floor((hits*epDmg-enemy.baseHealth)/enemy.healthScaling)}
 // Analytical sim: returns [expectedWave, subzone, totalTime] using CLT-based survival probabilities.
 // Iterates per SUBZONE (5 per wave) for intra-wave death resolution.
 // Metric matches FullEventSim.avgDistance: expectedSubzones/5 + 1.
@@ -503,7 +491,8 @@ function analyticalSim(player,enemy){
 
   let cumE=0,cumVar=0,expSub=0,time=0,currentWave=1,remainder=0,dead=false;
   for(let hitsToKill=1;hitsToKill<=10;hitsToKill++){
-    const maxWaveForHits=get_highest_wave_killed_in_x_hits(player,enemy,hitsToKill);
+    // Use expected player damage (with crits) for wave range assignment
+    const maxWaveForHits=get_highest_wave_killed_in_x_hits_expected(epDmg,enemy,hitsToKill);
     if(maxWaveForHits<currentWave)continue;
     const topWave=Math.min(maxWaveForHits,MAX_WAVE);
     for(let wave=currentWave;wave<=topWave;wave++){
@@ -516,9 +505,10 @@ function analyticalSim(player,enemy){
       const vHit=Math.max(0,eHit2-eHit*eHit);
       const enemyAtkSpd=enemy.atkSpeed+wave*0.02;
       const enemyHP=enemy.baseHealth+enemy.healthScaling*wave;
-      // Expected hitsToKill via Phi summation (corrects Jensen's inequality bias)
-      const htk=expectedHtk(enemyHP,epDmg,vpDmg);
-      const eHtkSub=htk.e,vHtk=htk.v;
+      // hitsToKill per subzone: use crit-adjusted expected damage
+      const eHtkSub=Math.max(1,Math.ceil(enemyHP/epDmg));
+      // Variance from hitsToKill uncertainty (delta method, conservative)
+      const vHtk=epDmg4>0?enemyHP*enemyHP*vpDmg/epDmg4:0;
       const atkRatio=enemyAtkSpd/player.atkSpeed;
       const timePerSub=(eHtkSub*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
       // Iterate 5 subzones per wave

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@ body{background:var(--bg);color:var(--t1);font-family:'Space Mono',monospace;fon
 <a href="#main-content" class="skip-link">Skip to content</a>
 
 <header class="header">
-  <h1 class="brand">⛏ OBELISK MINER EVENT SIM <span class="version">v2.4.0</span> <button class="help-btn" aria-label="Changelog" onclick="openChangelog()" style="margin-left:3px">?</button></h1>
+  <h1 class="brand">⛏ OBELISK MINER EVENT SIM <span class="version">v3.0.0</span> <button class="help-btn" aria-label="Changelog" onclick="openChangelog()" style="margin-left:3px">?</button></h1>
   <button class="res-btn" id="btn-export" onclick="exportState()">Export ▾</button>
   <button class="res-btn" onclick="importState()">Import ▴</button>
   <a href="stargazing.html" class="res-btn" style="text-decoration:none;display:inline-block">Stargazing ★</a>

--- a/index.html
+++ b/index.html
@@ -461,6 +461,25 @@ function avgEvent_short(player,enemy){
 }
 // Normal CDF via Hastings polynomial approximation (~700ns, 7.5e-8 accuracy)
 function Phi(z){if(z<-8)return 0;if(z>8)return 1;const t=1/(1+.2316419*Math.abs(z)),d=.3989423*Math.exp(-z*z/2),p=d*t*(.3193815+t*(-.3565638+t*(1.781478+t*(-1.821256+t*1.330274))));return z>0?1-p:p}
+// Exact E[htk] and Var[htk] for binary player damage (normal vs crit).
+function binomPMF(n,k,p){if(k<0||k>n)return 0;let c=1;for(let i=0;i<k;i++)c=c*(n-i)/(i+1);return c*Math.pow(p,k)*Math.pow(1-p,n-k)}
+function exactHtkMoments(hp,atk,pCrit,pCritDmg){
+  if(pCrit<=0||pCritDmg<=1){const h=Math.max(1,Math.ceil(hp/atk));return{mean:h,variance:0}}
+  if(pCrit>=1){const h=Math.max(1,Math.ceil(hp/round(atk*pCritDmg)));return{mean:h,variance:0}}
+  const nMax=Math.ceil(hp/atk),extra=round(atk*pCritDmg)-atk;
+  let prevCdf=0,mean=0,meanSq=0;
+  for(let n=1;n<=nMax;n++){
+    const shortfall=hp-atk*n;
+    let cdf;
+    if(shortfall<=0){cdf=1}
+    else{const kNeed=Math.ceil(shortfall/extra);if(kNeed>n){prevCdf=0;continue}let pLess=0;for(let k=0;k<kNeed;k++)pLess+=binomPMF(n,k,pCrit);cdf=1-pLess}
+    const pmf=cdf-prevCdf;
+    mean+=n*pmf;meanSq+=n*n*pmf;
+    prevCdf=cdf;
+    if(cdf>=1-1e-12)break;
+  }
+  return{mean:Math.max(1,mean),variance:Math.max(0,meanSq-mean*mean)}
+}
 // Analytical sim: returns [expectedWave, subzone, totalTime] using CLT-based survival probabilities.
 // Iterates per SUBZONE (5 per wave) for intra-wave death resolution.
 // Metric matches FullEventSim.avgDistance: expectedSubzones/5 + 1.
@@ -481,11 +500,6 @@ function analyticalSim(player,enemy){
   const hp=player.health;
   const pCrit=Math.max(0,player.crit)/100;
   const pCritDmg=Math.max(1,player.critDmg);
-  // Player damage moments for hitsToKill variance (H6 fix)
-  const epDmg=player.atk*(1+pCrit*(pCritDmg-1));
-  const epDmg2=player.atk*player.atk*(1+pCrit*(pCritDmg*pCritDmg-1));
-  const vpDmg=Math.max(0,epDmg2-epDmg*epDmg);
-  const epDmg4=epDmg*epDmg*epDmg*epDmg;
 
   let cumE=0,cumVar=0,expSub=0,time=0,remainder=0;
   for(let wave=1;wave<=MAX_WAVE;wave++){
@@ -493,24 +507,23 @@ function analyticalSim(player,enemy){
     const baseDmg=Math.max(1,round(enemy.atk+wave*enemy.atkScaling));
     const eCrit=Math.max(0,Math.min(1,(enemy.crit+wave)/100));
     const eCritMul=Math.max(1,enemy.critDmg+wave*enemy.critDmgScaling);
-    const eHit=(1-block)*baseDmg*(1+eCrit*(eCritMul-1));
-    const eHit2=(1-block)*baseDmg*baseDmg*(1+eCrit*(eCritMul*eCritMul-1));
+    const eCritDmg=eCritMul>1?round(baseDmg*eCritMul):baseDmg;
+    const eHit=(1-block)*((1-eCrit)*baseDmg+eCrit*eCritDmg);
+    const eHit2=(1-block)*((1-eCrit)*baseDmg*baseDmg+eCrit*eCritDmg*eCritDmg);
     const vHit=Math.max(0,eHit2-eHit*eHit);
     const enemyAtkSpd=enemy.atkSpeed+wave*0.02;
     const enemyHP=enemy.baseHealth+enemy.healthScaling*wave;
-    // Expected hitsToKill using average player damage (with crits)
-    const eHtkSub=Math.max(1,Math.ceil(enemyHP/epDmg));
-    // Variance from hitsToKill uncertainty (delta method)
-    const vHtk=epDmg4>0?enemyHP*enemyHP*vpDmg/epDmg4:0;
+    // Exact E[htk] and Var[htk] via binomial player crit distribution
+    const htk=exactHtkMoments(enemyHP,player.atk,pCrit,pCritDmg);
     const atkRatio=enemyAtkSpd/player.atkSpeed;
-    const timePerSub=(eHtkSub*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
+    const timePerSub=(htk.mean*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
     let dead=false;
     // Iterate 5 subzones per wave
     for(let s=0;s<5;s++){
-      const rawHits=remainder+eHtkSub*atkRatio;
+      const rawHits=remainder+htk.mean*atkRatio;
       remainder=rawHits%1;
       const eHw=Math.floor(rawHits);
-      const vHw=vHtk*atkRatio*atkRatio;
+      const vHw=htk.variance*atkRatio*atkRatio;
       cumE+=eHw*eHit;
       cumVar+=eHw*vHit+vHw*eHit*eHit;
       let pSurv;

--- a/index.html
+++ b/index.html
@@ -461,8 +461,6 @@ function avgEvent_short(player,enemy){
 }
 // Normal CDF via Hastings polynomial approximation (~700ns, 7.5e-8 accuracy)
 function Phi(z){if(z<-8)return 0;if(z>8)return 1;const t=1/(1+.2316419*Math.abs(z)),d=.3989423*Math.exp(-z*z/2),p=d*t*(.3193815+t*(-.3565638+t*(1.781478+t*(-1.821256+t*1.330274))));return z>0?1-p:p}
-// Like get_highest_wave_killed_in_x_hits but using expected player damage (with crits)
-function get_highest_wave_killed_in_x_hits_expected(epDmg,enemy,hits){return Math.floor((hits*epDmg-enemy.baseHealth)/enemy.healthScaling)}
 // Analytical sim: returns [expectedWave, subzone, totalTime] using CLT-based survival probabilities.
 // Iterates per SUBZONE (5 per wave) for intra-wave death resolution.
 // Metric matches FullEventSim.avgDistance: expectedSubzones/5 + 1.
@@ -489,52 +487,40 @@ function analyticalSim(player,enemy){
   const vpDmg=Math.max(0,epDmg2-epDmg*epDmg);
   const epDmg4=epDmg*epDmg*epDmg*epDmg;
 
-  let cumE=0,cumVar=0,expSub=0,time=0,currentWave=1,remainder=0,dead=false;
-  for(let hitsToKill=1;hitsToKill<=10;hitsToKill++){
-    // Use expected player damage (with crits) for wave range assignment
-    const maxWaveForHits=get_highest_wave_killed_in_x_hits_expected(epDmg,enemy,hitsToKill);
-    if(maxWaveForHits<currentWave)continue;
-    const topWave=Math.min(maxWaveForHits,MAX_WAVE);
-    for(let wave=currentWave;wave<=topWave;wave++){
-      // Enemy damage moments per hit at this wave
-      const baseDmg=Math.max(1,round(enemy.atk+wave*enemy.atkScaling));
-      const eCrit=Math.max(0,Math.min(1,(enemy.crit+wave)/100));
-      const eCritMul=Math.max(1,enemy.critDmg+wave*enemy.critDmgScaling);
-      const eHit=(1-block)*baseDmg*(1+eCrit*(eCritMul-1));
-      const eHit2=(1-block)*baseDmg*baseDmg*(1+eCrit*(eCritMul*eCritMul-1));
-      const vHit=Math.max(0,eHit2-eHit*eHit);
-      const enemyAtkSpd=enemy.atkSpeed+wave*0.02;
-      const enemyHP=enemy.baseHealth+enemy.healthScaling*wave;
-      // hitsToKill per subzone: use crit-adjusted expected damage
-      const eHtkSub=Math.max(1,Math.ceil(enemyHP/epDmg));
-      // Variance from hitsToKill uncertainty (delta method, conservative)
-      const vHtk=epDmg4>0?enemyHP*enemyHP*vpDmg/epDmg4:0;
-      const atkRatio=enemyAtkSpd/player.atkSpeed;
-      const timePerSub=(eHtkSub*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
-      // Iterate 5 subzones per wave
-      for(let s=0;s<5;s++){
-        // Enemy hits this subzone using crit-adjusted hitsToKill
-        const rawHits=remainder+eHtkSub*atkRatio;
-        remainder=rawHits%1;
-        const eHw=Math.floor(rawHits);
-        // Variance from hitsToKill uncertainty: Var[hits] = Var[htk] * ratio^2
-        const vHw=vHtk*atkRatio*atkRatio;
-        // Accumulate cumulative damage (law of total variance)
-        cumE+=eHw*eHit;
-        cumVar+=eHw*vHit+vHw*eHit*eHit;
-        // Survival probability after this subzone
-        let pSurv;
-        if(cumVar<=0)pSurv=hp>cumE?1:0;
-        else pSurv=Phi((hp-cumE)/Math.sqrt(cumVar));
-        expSub+=pSurv;
-        time+=timePerSub;
-        if(pSurv<1e-9){dead=true;break;}
-      }
-      if(dead)break;
+  let cumE=0,cumVar=0,expSub=0,time=0,remainder=0;
+  for(let wave=1;wave<=MAX_WAVE;wave++){
+    // Enemy damage moments per hit at this wave
+    const baseDmg=Math.max(1,round(enemy.atk+wave*enemy.atkScaling));
+    const eCrit=Math.max(0,Math.min(1,(enemy.crit+wave)/100));
+    const eCritMul=Math.max(1,enemy.critDmg+wave*enemy.critDmgScaling);
+    const eHit=(1-block)*baseDmg*(1+eCrit*(eCritMul-1));
+    const eHit2=(1-block)*baseDmg*baseDmg*(1+eCrit*(eCritMul*eCritMul-1));
+    const vHit=Math.max(0,eHit2-eHit*eHit);
+    const enemyAtkSpd=enemy.atkSpeed+wave*0.02;
+    const enemyHP=enemy.baseHealth+enemy.healthScaling*wave;
+    // Expected hitsToKill using average player damage (with crits)
+    const eHtkSub=Math.max(1,Math.ceil(enemyHP/epDmg));
+    // Variance from hitsToKill uncertainty (delta method)
+    const vHtk=epDmg4>0?enemyHP*enemyHP*vpDmg/epDmg4:0;
+    const atkRatio=enemyAtkSpd/player.atkSpeed;
+    const timePerSub=(eHtkSub*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
+    let dead=false;
+    // Iterate 5 subzones per wave
+    for(let s=0;s<5;s++){
+      const rawHits=remainder+eHtkSub*atkRatio;
+      remainder=rawHits%1;
+      const eHw=Math.floor(rawHits);
+      const vHw=vHtk*atkRatio*atkRatio;
+      cumE+=eHw*eHit;
+      cumVar+=eHw*vHit+vHw*eHit*eHit;
+      let pSurv;
+      if(cumVar<=0)pSurv=hp>cumE?1:0;
+      else pSurv=Phi((hp-cumE)/Math.sqrt(cumVar));
+      expSub+=pSurv;
+      time+=timePerSub;
+      if(pSurv<1e-9){dead=true;break;}
     }
     if(dead)break;
-    currentWave=topWave+1;
-    if(currentWave>MAX_WAVE)break;
   }
   // Convert subzones to FullEventSim-compatible metric: distance = subzones/5 + 1
   const expectedWave=expSub/5+1;

--- a/index.html
+++ b/index.html
@@ -156,6 +156,9 @@ body{background:var(--bg);color:var(--t1);font-family:'Space Mono',monospace;fon
 .pres-milestone{font-size:var(--fs-xs);color:var(--t2);margin-top:8px;padding-top:8px;border-top:1px solid var(--b1)}
 .pres-milestone b{color:var(--t1)}
 .pres-milestone .pres-ms-wave{color:var(--acc-dim)}
+.pres-advisor{font-size:var(--fs-xs);padding:4px 0;color:var(--t3)}
+.pres-advisor.go{color:var(--acc);font-weight:600}
+.pres-advisor.done{font-style:italic}
 
 
 /* ── Scrollbar ───────────────────────────── */
@@ -245,6 +248,7 @@ body{background:var(--bg);color:var(--t1);font-family:'Space Mono',monospace;fon
       </div>
       <div id="gem-upgrades"></div>
       <div id="pres-milestone" class="pres-milestone"></div>
+      <div id="pres-advisor" class="pres-advisor"></div>
       <button class="res-btn" style="width:100%;margin-top:6px" onclick="prestigeReset()">Reset Upgrades</button>
       <div style="font-size:var(--fs-micro);color:var(--t3);margin-top:4px;text-align:center">Update prestige count above after resetting</div>
     </div>
@@ -896,6 +900,26 @@ function renderPrestigeMilestone(){
   const wave=nextP*5+5;
   el.innerHTML=`Next unlock: <b>Prestige ${nextP}</b> <span class="pres-ms-wave">(Wave ${wave})</span> - ${unlockCount} upgrade${unlockCount>1?'s':''}`;
 }
+const PRESTIGE_MILESTONES=[1,2,5,10,20,40];
+function renderPrestigeAdvice(){
+  const el=document.getElementById('pres-advisor');
+  if(!el)return;
+  const base=approxCache['base'];
+  if(!base){el.textContent='';return}
+  const wave=base[0];
+  const next=PRESTIGE_MILESTONES.find(m=>m>prestigeCount);
+  if(!next){el.textContent='All prestige milestones reached.';el.className='pres-advisor done';return}
+  const reqWave=next*5+5;
+  const steps=next-prestigeCount;
+  if(wave>=reqWave){
+    el.textContent=`Prestige recommended - target P${next}`+(steps>1?` (${steps}x prestige)`:'');
+    el.className='pres-advisor go';
+  }else{
+    const delta=(reqWave-wave).toFixed(1);
+    el.textContent=`Farm to wave ${reqWave} for P${next} (need ${delta} more waves)`;
+    el.className='pres-advisor wait';
+  }
+}
 function refreshGemValues(){
   for(let i=0;i<upgradeNames_gem.length;i++){
     const lvl=gemUp[i]||0,maxL=currentMaxLvl_gem(i);
@@ -1271,6 +1295,7 @@ function runAndRender(){
   refreshGemValues();
   refreshUpgradeValues();
   renderPrestigeMilestone();
+  renderPrestigeAdvice();
   document.getElementById('pres-input').value=prestigeCount;
   saveState();
 }

--- a/index.html
+++ b/index.html
@@ -908,7 +908,11 @@ function renderPrestigeAdvice(){
   if(!base){el.textContent='';return}
   const wave=base[0];
   const next=PRESTIGE_MILESTONES.find(m=>m>prestigeCount);
-  if(!next){el.textContent='All prestige milestones reached.';el.className='pres-advisor done';return}
+  if(!next){
+    if(wave<250){const d=(250-wave).toFixed(1);el.textContent=`Farm to wave 250 for all rewards (need ${d} more waves)`;el.className='pres-advisor wait'}
+    else{el.textContent='All rewards claimed.';el.className='pres-advisor done'}
+    return;
+  }
   const reqWave=next*5+5;
   const steps=next-prestigeCount;
   if(wave>=reqWave){

--- a/index.html
+++ b/index.html
@@ -498,10 +498,21 @@ function analyticalSim(player,enemy){
     const vHit=Math.max(0,eHit2-eHit*eHit);
     const enemyAtkSpd=enemy.atkSpeed+wave*0.02;
     const enemyHP=enemy.baseHealth+enemy.healthScaling*wave;
-    // Expected hitsToKill using average player damage (with crits)
-    const eHtkSub=Math.max(1,Math.ceil(enemyHP/epDmg));
-    // Variance from hitsToKill uncertainty (delta method)
-    const vHtk=epDmg4>0?enemyHP*enemyHP*vpDmg/epDmg4:0;
+    // Expected hitsToKill via Phi summation: E[htk] = Σ P(htk > n)
+    // Corrects Jensen's inequality bias from ceil(HP/E[dmg]) >= E[ceil(HP/dmg)]
+    let eHtkSub=1,vHtk=0;
+    if(vpDmg>0){
+      let ehtk=1,ehtk2=1;// n=0: P(htk>0)=1, contributes 1 to E and 1 to E[X²]
+      for(let n=1;n<20;n++){
+        const pGt=Phi((enemyHP-n*epDmg)/Math.sqrt(n*vpDmg));
+        if(pGt<1e-9)break;
+        ehtk+=pGt;ehtk2+=(2*n+1)*pGt;
+      }
+      eHtkSub=Math.max(1,ehtk);
+      vHtk=Math.max(0,ehtk2-ehtk*ehtk);
+    }else{
+      eHtkSub=Math.max(1,Math.ceil(enemyHP/Math.max(1,epDmg)));
+    }
     const atkRatio=enemyAtkSpd/player.atkSpeed;
     const timePerSub=(eHtkSub*player.defaultAtkTime/player.atkSpeed+player.defaultWalkTime/player.walkSpeed)/player.gameSpeed;
     let dead=false;


### PR DESCRIPTION
## Problem / Intent

Gain calculation used Monte Carlo (200 paired runs) with bias from Math.max(0), noise, and ~373ms per refresh. Two optimization modes (res/min + max wave) plus Cycle Resource button added unnecessary complexity. The user's real goal is always pushing the highest wave.

## Approach

Replace the entire gain system with a CLT-based analytical simulation (deterministic, ~18ms per refresh, ~20x faster). Single "max wave" optimization target.

Key changes:
- `analyticalSim`: CLT-based expected wave computation with exact binomial htk moments
- Upgrade type classification (combat/speed/resource/prestige/mixed/cap) with 2-pass gain computation
- Indirect value formulas for speed, resource, and prestige upgrades
- Cap compound gain showing cascading value from unlocked upgrades
- Budget planner 2-step lookahead for better upgrade sequencing
- Prestige advisor using official wiki optimal milestones (P1/P2/P5/P10/P20/P40)
- Deleted: res/min mode, Cycle Resource button, MC gain functions (-82 lines net in Step 2)